### PR TITLE
fix(run): handle M: drive drop during post-pipeline cleanup (#87)

### DIFF
--- a/01_Analysis/00-Scripts/analytics/attrition/dimensions.py
+++ b/01_Analysis/00-Scripts/analytics/attrition/dimensions.py
@@ -67,9 +67,19 @@ def _by_branch(ctx: PipelineContext) -> list[AnalysisResult]:
 
     bmap = getattr(ctx.settings, "branch_mapping", None) or {}
 
-    # Use the system-wide L12M window
-    ctx.compute_l12m_window()
-    l12m_closed = closed[ctx.in_l12m(closed["Date Closed"])].copy()
+    # Use the system-wide L12M window (set by steps/subsets.py on ctx.start_date / ctx.end_date)
+    sd, ed = ctx.start_date, ctx.end_date
+    if sd is None or ed is None:
+        return [
+            AnalysisResult(
+                slide_id="A9.4",
+                title="L12M Attrition by Branch",
+                success=False,
+                error="L12M window not set on context",
+            )
+        ]
+    _dc = pd.to_datetime(closed["Date Closed"], errors="coerce")
+    l12m_closed = closed[(_dc >= pd.Timestamp(sd)) & (_dc <= pd.Timestamp(ed))].copy()
 
     # Denominator: accounts open at start of L12M window
     # Approximation: currently open + closed in L12M
@@ -124,7 +134,7 @@ def _by_branch(ctx: PipelineContext) -> list[AnalysisResult]:
                 va="center",
                 fontsize=DATA_LABEL_SIZE - 4,
             )
-        _l12m_label = f"{ctx.l12m_start.strftime('%b %Y')} - {ctx.l12m_end.strftime('%b %Y')}"
+        _l12m_label = f"{pd.Timestamp(sd).strftime('%b %Y')} - {pd.Timestamp(ed).strftime('%b %Y')}"
         ax.set_title(
             f"L12M Attrition Rate by Branch\n({_l12m_label})",
             fontsize=24,
@@ -168,7 +178,8 @@ def _by_branch(ctx: PipelineContext) -> list[AnalysisResult]:
 
     # --- A9.4b: First-Year Close Rate by Branch ---
     # Accounts opened in L12M that also closed in L12M
-    l12m_opened = all_data[ctx.in_l12m(all_data["Date Opened"])].copy()
+    _do = pd.to_datetime(all_data["Date Opened"], errors="coerce")
+    l12m_opened = all_data[(_do >= pd.Timestamp(sd)) & (_do <= pd.Timestamp(ed))].copy()
     l12m_opened = _apply_branch_map(l12m_opened, bmap)
 
     if not l12m_opened.empty:

--- a/01_Analysis/00-Scripts/analytics/competition/10_biz_vs_personal.py
+++ b/01_Analysis/00-Scripts/analytics/competition/10_biz_vs_personal.py
@@ -95,9 +95,12 @@ if len(all_competitor_data) > 0:
         plt.show()
 
         # Opportunity callout
-        biz_pct = biz_split.loc['Business', 'transactions'] / biz_split['transactions'].sum() * 100
-        if biz_pct > 30:
-            print(f"\n    OPPORTUNITY: Business accounts represent {biz_pct:.0f}% of competitor transactions.")
-            print("    High-value business relationships at risk -- prioritize commercial retention.")
+        if 'Business' in biz_split.index:
+            biz_pct = biz_split.loc['Business', 'transactions'] / biz_split['transactions'].sum() * 100
+            if biz_pct > 30:
+                print(f"\n    OPPORTUNITY: Business accounts represent {biz_pct:.0f}% of competitor transactions.")
+                print("    High-value business relationships at risk -- prioritize commercial retention.")
+        else:
+            print("\n    No business accounts in data -- personal-only portfolio.")
     else:
         print("No business_flag column found in competitor data.")

--- a/01_Analysis/00-Scripts/analytics/dctr/_helpers.py
+++ b/01_Analysis/00-Scripts/analytics/dctr/_helpers.py
@@ -336,9 +336,10 @@ def branch_dctr(
     if dataset.empty:
         return pd.DataFrame(), {}
     dc = dataset.copy()
+    dc["Branch"] = dc["Branch"].astype(str)
     if branch_mapping:
         str_mapping = {str(k): v for k, v in branch_mapping.items()}
-        mapped = dc["Branch"].astype(str).map(str_mapping)
+        mapped = dc["Branch"].map(str_mapping)
         dc["Branch Name"] = mapped.where(mapped.notna(), dc["Branch"])
     else:
         dc["Branch Name"] = dc["Branch"]

--- a/01_Analysis/00-Scripts/analytics/dctr/branches.py
+++ b/01_Analysis/00-Scripts/analytics/dctr/branches.py
@@ -132,9 +132,10 @@ class DCTRBranches(AnalysisModule):
         dc = ed.copy()
         dc["Date Opened"] = pd.to_datetime(dc["Date Opened"], errors="coerce", format="mixed")
         dc["Account Age Days"] = (pd.Timestamp.now() - dc["Date Opened"]).dt.days
+        dc["Branch"] = dc["Branch"].astype(str)
         if bm:
             str_bm = {str(k): v for k, v in bm.items()}
-            mapped = dc["Branch"].astype(str).map(str_bm)
+            mapped = dc["Branch"].map(str_bm)
             dc["Branch Name"] = mapped.where(mapped.notna(), dc["Branch"])
         else:
             dc["Branch Name"] = dc["Branch"]
@@ -197,9 +198,10 @@ class DCTRBranches(AnalysisModule):
         dc = ed.copy()
         dc["Date Opened"] = pd.to_datetime(dc["Date Opened"], errors="coerce", format="mixed")
         dc["Month_Year"] = dc["Date Opened"].dt.strftime("%b%y")
+        dc["Branch"] = dc["Branch"].astype(str)
         if bm:
             str_bm = {str(k): v for k, v in bm.items()}
-            mapped = dc["Branch"].astype(str).map(str_bm)
+            mapped = dc["Branch"].map(str_bm)
             dc["Branch Name"] = mapped.where(mapped.notna(), dc["Branch"])
         else:
             dc["Branch Name"] = dc["Branch"]
@@ -505,9 +507,10 @@ class DCTRBranches(AnalysisModule):
         dc = ed.copy()
         dc["Date Opened"] = pd.to_datetime(dc["Date Opened"], errors="coerce", format="mixed")
         dc["Month_Year"] = dc["Date Opened"].dt.strftime("%b%y")
+        dc["Branch"] = dc["Branch"].astype(str)
         if bm:
             str_bm = {str(k): v for k, v in bm.items()}
-            mapped = dc["Branch"].astype(str).map(str_bm)
+            mapped = dc["Branch"].map(str_bm)
             dc["Branch Name"] = mapped.where(mapped.notna(), dc["Branch"])
         else:
             dc["Branch Name"] = dc["Branch"]

--- a/01_Analysis/00-Scripts/analytics/financial_services/15_biz_vs_personal.py
+++ b/01_Analysis/00-Scripts/analytics/financial_services/15_biz_vs_personal.py
@@ -55,9 +55,12 @@ if 'business_flag' in all_finserv_trans.columns:
     plt.subplots_adjust(bottom=0.08)
     plt.show()
 
-    biz_pct = biz_split.loc['Business', 'accounts'] / biz_split['accounts'].sum() * 100
-    if biz_pct > 20:
-        print(f"\n    OPPORTUNITY: Business accounts represent {biz_pct:.0f}% of external FinServ leakage.")
-        print("    These are high-value relationships -- prioritize commercial product offers.")
+    if 'Business' in biz_split.index:
+        biz_pct = biz_split.loc['Business', 'accounts'] / biz_split['accounts'].sum() * 100
+        if biz_pct > 20:
+            print(f"\n    OPPORTUNITY: Business accounts represent {biz_pct:.0f}% of external FinServ leakage.")
+            print("    These are high-value relationships -- prioritize commercial product offers.")
+    else:
+        print("\n    No business accounts in data -- personal-only portfolio.")
 else:
     print("No business_flag column available. Skipping Business vs Personal analysis.")

--- a/01_Analysis/00-Scripts/analytics/rege/dimensions.py
+++ b/01_Analysis/00-Scripts/analytics/rege/dimensions.py
@@ -469,9 +469,17 @@ class RegEDimensions(AnalysisModule):
                 }
             )
         result = pd.DataFrame(rows)
-        if not result.empty:
-            result = result.sort_values("Total Accounts", ascending=False)
-            result = total_row(result, "Product Code")
+        if result.empty:
+            return [
+                AnalysisResult(
+                    slide_id="A8.7",
+                    title="Reg E by Product Code",
+                    success=False,
+                    error="No product code groups with Reg E data",
+                )
+            ]
+        result = result.sort_values("Total Accounts", ascending=False)
+        result = total_row(result, "Product Code")
 
         # Chart -- top 15
         chart_path = None

--- a/01_Analysis/00-Scripts/pipeline/steps/analyze.py
+++ b/01_Analysis/00-Scripts/pipeline/steps/analyze.py
@@ -69,6 +69,24 @@ def step_analyze(ctx: PipelineContext) -> None:
         skip=skip_count,
         fail=fail_count,
     )
+    _log_soft_failures(ctx)
+
+
+def _log_soft_failures(ctx: PipelineContext) -> None:
+    """Summarize AnalysisResult entries with success=False (caught by _safe wrappers).
+
+    Module-level failures are already logged above. This surfaces the per-slide
+    failures that would otherwise only be visible as scattered WARNING lines.
+    """
+    soft = [r for r in ctx.all_slides if not getattr(r, "success", True)]
+    if not soft:
+        return
+    logger.warning(
+        "{n} slide(s) skipped with errors (non-fatal -- see warnings above):",
+        n=len(soft),
+    )
+    for r in soft:
+        logger.warning("  {sid}: {title} -- {err}", sid=r.slide_id, title=r.title, err=r.error)
 
 
 def step_analyze_selected(ctx: PipelineContext, module_ids: list[str]) -> None:
@@ -117,3 +135,4 @@ def step_analyze_selected(ctx: PipelineContext, module_ids: list[str]) -> None:
         skip=skip_count,
         fail=fail_count,
     )
+    _log_soft_failures(ctx)

--- a/01_Analysis/run.py
+++ b/01_Analysis/run.py
@@ -362,7 +362,16 @@ def main():
         import shutil
         gc.collect()  # release any file handles held by python-pptx/matplotlib
 
-        pptx_files = [f for f in output_dir.iterdir() if f.suffix == '.pptx']
+        try:
+            pptx_files = [f for f in output_dir.iterdir() if f.suffix == '.pptx']
+        except OSError as _e:
+            # Network mount (M:) can drop during long runs -- WinError 53 / 67.
+            # Analysis already completed, so warn and skip the PPTX move.
+            print()
+            print(f"  WARNING: Could not access {output_dir} to move PPTX files.")
+            print(f"    {_e}")
+            print(f"    The M: drive may have disconnected. Check the folder manually once it reconnects.")
+            pptx_files = []
         for pf in pptx_files:
             dest = pptx_dir / pf.name
             for _attempt in range(3):
@@ -397,16 +406,22 @@ def main():
 
         # List output files
         print("    Excel/Data:")
-        for f in output_dir.iterdir():
-            if f.suffix in ('.xlsx', '.json') and client_id in f.name:
-                size_mb = f.stat().st_size / (1024 * 1024)
-                print(f"      {f.name} ({size_mb:.1f} MB)")
+        try:
+            for f in output_dir.iterdir():
+                if f.suffix in ('.xlsx', '.json') and client_id in f.name:
+                    size_mb = f.stat().st_size / (1024 * 1024)
+                    print(f"      {f.name} ({size_mb:.1f} MB)")
+        except OSError as _e:
+            print(f"      (could not list {output_dir}: {_e})")
 
         print("    PowerPoint:")
-        for f in pptx_dir.iterdir():
-            if f.suffix == '.pptx':
-                size_mb = f.stat().st_size / (1024 * 1024)
-                print(f"      {f.name} ({size_mb:.1f} MB)")
+        try:
+            for f in pptx_dir.iterdir():
+                if f.suffix == '.pptx':
+                    size_mb = f.stat().st_size / (1024 * 1024)
+                    print(f"      {f.name} ({size_mb:.1f} MB)")
+        except OSError as _e:
+            print(f"      (could not list {pptx_dir}: {_e})")
 
         print("=" * 70)
         print()


### PR DESCRIPTION
Wrap the three output_dir/pptx_dir iterdir() calls in try/except so a
dropped network mount at cleanup time surfaces a clear warning instead
of a raw FileNotFoundError traceback. The analysis itself already
succeeded by that point (97 slides generated), so this keeps the run's
exit path graceful.