### PR TITLE
TXN pipeline hardening: fix issue #92 silent failures + deck-size control

### DIFF
--- a/01_Analysis/00-Scripts/analytics/attrition_txn/02_attrition_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/attrition_txn/02_attrition_kpi.py
@@ -60,7 +60,7 @@ for ax, (value, label, color) in zip(axes, kpis):
 
 fig.suptitle("Attrition Risk at a Glance",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 fig.text(0.5, 0.98, f"Based on 3-month vs 12-month velocity ratios | {DATASET_LABEL}",
          fontsize=14, color=GEN_COLORS['muted'], style='italic',
          ha='center')

--- a/01_Analysis/00-Scripts/analytics/attrition_txn/05_monthly_progression.py
+++ b/01_Analysis/00-Scripts/analytics/attrition_txn/05_monthly_progression.py
@@ -17,10 +17,24 @@ else:
         .reset_index()
     )
 
-    # Get ordered month labels from the data
-    _month_order = monthly_spend_ts['month_label'].unique()
-    # Sort chronologically by parsing MmmYY format
-    _month_sort = sorted(_month_order, key=lambda m: pd.to_datetime(m, format='%b%y'))
+    # Get ordered month labels from the data. Filter out any aggregate
+    # labels (``Total'', ``YTD'', ``Avg'') that can creep in from upstream
+    # rollups -- they crash pd.to_datetime(format='%b%y').
+    _month_order = [
+        m for m in monthly_spend_ts['month_label'].unique()
+        if isinstance(m, str) and m not in ('Total', 'YTD', 'Avg', 'Average', 'All')
+    ]
+    # Sort chronologically by parsing MmmYY format. Skip any label that
+    # doesn't parse instead of crashing the whole script.
+    def _safe_parse_month(label):
+        try:
+            return pd.to_datetime(label, format='%b%y')
+        except (ValueError, TypeError):
+            return pd.Timestamp.max
+    _month_sort = sorted(_month_order, key=_safe_parse_month)
+    # Drop any label that didn't parse (got Timestamp.max) so the x-axis
+    # doesn't show an unsortable bucket at the far right.
+    _month_sort = [m for m in _month_sort if _safe_parse_month(m) != pd.Timestamp.max]
     _tier_monthly['month_label'] = pd.Categorical(
         _tier_monthly['month_label'], categories=_month_sort, ordered=True
     )

--- a/01_Analysis/00-Scripts/analytics/attrition_txn/08_risk_by_competitor.py
+++ b/01_Analysis/00-Scripts/analytics/attrition_txn/08_risk_by_competitor.py
@@ -106,7 +106,7 @@ else:
 
     fig.suptitle("Competitor Activity Among Declining Members",
                  fontsize=24, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
     fig.text(0.5, 0.99,
              f"Are at-risk members switching or just spending less? | {DATASET_LABEL}",
              fontsize=14, color=GEN_COLORS['muted'], style='italic', ha='center')

--- a/01_Analysis/00-Scripts/analytics/attrition_txn/10_dormancy_progression.py
+++ b/01_Analysis/00-Scripts/analytics/attrition_txn/10_dormancy_progression.py
@@ -129,7 +129,7 @@ else:
 
     fig.suptitle("Dormancy Progression",
                  fontsize=24, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
     fig.text(0.5, 0.99, f"How long have inactive accounts been silent? | {DATASET_LABEL}",
              fontsize=14, color=GEN_COLORS['muted'], style='italic', ha='center')
 

--- a/01_Analysis/00-Scripts/analytics/balance/02_balance_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/balance/02_balance_kpi.py
@@ -57,7 +57,7 @@ for ax, kpi in zip(axes, kpi_data):
 
 fig.suptitle("Deposit Portfolio Overview",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/balance/07_balance_by_demographics.py
+++ b/01_Analysis/00-Scripts/analytics/balance/07_balance_by_demographics.py
@@ -147,7 +147,7 @@ axes[2].tick_params(axis='x', rotation=30)
 # ---------------------------------------------------------------------------
 fig.suptitle("Balance Profile by Demographics",
              fontsize=26, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 fig.text(0.01, 1.00,
          f"Median balance across key segmentation dimensions | {DATASET_LABEL}",
          fontsize=12, style='italic', color=GEN_COLORS['muted'])

--- a/01_Analysis/00-Scripts/analytics/balance/08_pfi_scoring.py
+++ b/01_Analysis/00-Scripts/analytics/balance/08_pfi_scoring.py
@@ -162,7 +162,7 @@ gen_clean_axes(axes[1])
 
 fig.suptitle("Primary Financial Institution (PFI) Score Analysis",
              fontsize=26, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 fig.text(0.01, 1.00,
          f"Score = Balance(0-5) + Activity(0-5) + Tenure(0-3) + Products(0-3) | {DATASET_LABEL}",
          fontsize=12, style='italic', color=GEN_COLORS['muted'])

--- a/01_Analysis/00-Scripts/analytics/branch_txn/01_branch_data.py
+++ b/01_Analysis/00-Scripts/analytics/branch_txn/01_branch_data.py
@@ -13,7 +13,27 @@ try:
     # Place file as branch_config.json in repo root or 10-branch/ folder.
     # ------------------------------------------------------------------
     BRANCH_NAME_MAP = {}
-    _br_config_paths = [
+    # Prefer client-specific config under M:\ARS\03_Config\branch_configs\ so
+    # different clients can have different branch maps; fall back to a single
+    # shared file, then to CWD-relative locations for Jupyter users.
+    _client_id = globals().get('CLIENT_ID') or os.environ.get('CLIENT_ID', '')
+    _ars_base_candidates = [
+        os.environ.get('ARS_BASE', ''),
+        r'M:\ARS',
+        '/Volumes/M/ARS',
+    ]
+    _ars_base = next((p for p in _ars_base_candidates if p and os.path.isdir(p)), '')
+
+    _br_config_paths = []
+    if _ars_base:
+        if _client_id:
+            _br_config_paths.append(os.path.join(
+                _ars_base, '03_Config', 'branch_configs', f'{_client_id}.json',
+            ))
+        _br_config_paths.append(os.path.join(
+            _ars_base, '03_Config', 'branch_config.json',
+        ))
+    _br_config_paths += [
         os.path.join(os.path.dirname(os.getcwd()), 'branch_config.json'),
         os.path.join(os.getcwd(), 'branch_config.json'),
         'branch_config.json',
@@ -34,8 +54,22 @@ try:
             break
 
     if not BRANCH_NAME_MAP:
-        print("    WARNING: branch_config.json not found. Branch names will show as numbers.")
-        print("    Place branch_config.json in repo root with format: {\"1\": \"Main Office\", ...}")
+        # Loud, visible warning block so the missing-config issue doesn't
+        # silently propagate as numeric branch names in every chart.
+        print()
+        print("    " + "!" * 56)
+        print("    ! WARNING: branch_config.json not found            !")
+        print("    ! Branch names will display as numeric IDs.        !")
+        print("    !                                                  !")
+        print("    ! Preferred locations (first match wins):          !")
+        if _ars_base and _client_id:
+            print(f"    !   {_ars_base}\\03_Config\\branch_configs\\{_client_id}.json")
+        if _ars_base:
+            print(f"    !   {_ars_base}\\03_Config\\branch_config.json")
+        print("    !                                                  !")
+        print("    ! Format: {\"1\": \"Main Office\", \"2\": \"West\", ...} !")
+        print("    " + "!" * 56)
+        print()
 
     # Merge Branch onto combined_df
     br_subset = rewards_df[['Acct Number', 'Branch']].copy()

--- a/01_Analysis/00-Scripts/analytics/branch_txn/02_branch_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/branch_txn/02_branch_kpi.py
@@ -63,7 +63,7 @@ else:
 
     fig.suptitle("Branch Geographic Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
     plt.tight_layout()
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/branch_txn/04_branch_spend_comparison.py
+++ b/01_Analysis/00-Scripts/analytics/branch_txn/04_branch_spend_comparison.py
@@ -49,8 +49,8 @@ else:
 
     fig.suptitle("Branch Spend & Activity Comparison",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "Which branches have the highest-value and most active accounts?",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "Which branches have the highest-value and most active accounts?",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/branch_txn/branch_config.sample.json
+++ b/01_Analysis/00-Scripts/analytics/branch_txn/branch_config.sample.json
@@ -1,0 +1,15 @@
+{
+  "_doc": "Branch number -> branch name mapping. Copy this file, rename it, fill in your client's branches, and place at one of the locations below (the loader checks them in order):",
+  "_locations": [
+    "M:/ARS/03_Config/branch_configs/{CLIENT_ID}.json   (client-specific, preferred)",
+    "M:/ARS/03_Config/branch_config.json                (shared default, used when no client-specific file)"
+  ],
+  "_format_note": "Keys MUST be strings (e.g. \"1\" not 1) because branch numbers from the ODD file may be int OR float (e.g. 1.0). The loader handles both via the .split('.') step in branch_txn/01_branch_data.py. Strip leading zeros if your CU stores branches as 001 -- keys here should match what the ODD column emits.",
+  "_remove_underscored_keys_before_use": "Lines starting with _ are documentation only. Remove them in your real config (or leave them -- json.load will tolerate them since they're just unused keys).",
+
+  "1": "Main Office",
+  "2": "Downtown Branch",
+  "3": "West Branch",
+  "4": "North Branch",
+  "5": "South Branch"
+}

--- a/01_Analysis/00-Scripts/analytics/business_accts/02_business_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/business_accts/02_business_kpi.py
@@ -60,7 +60,7 @@ else:
 
     fig.suptitle("Business Account Portfolio Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
     plt.tight_layout()
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/business_accts/04_business_donut.py
+++ b/01_Analysis/00-Scripts/analytics/business_accts/04_business_donut.py
@@ -75,7 +75,7 @@ else:
 
     fig.suptitle("Business Account Merchant Breakdown",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
     plt.tight_layout()
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/business_accts/08_business_volatility.py
+++ b/01_Analysis/00-Scripts/analytics/business_accts/08_business_volatility.py
@@ -52,8 +52,8 @@ else:
 
     fig.suptitle("Business Merchant Spend Consistency",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "Stable vs spiky business merchants ($10K+ spend, 3+ months, CV capped at 500%)",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "Stable vs spiky business merchants ($10K+ spend, 3+ months, CV capped at 500%)",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/business_accts/10_business_vs_portfolio.py
+++ b/01_Analysis/00-Scripts/analytics/business_accts/10_business_vs_portfolio.py
@@ -55,8 +55,8 @@ else:
 
         fig.suptitle("Business vs Full Portfolio",
                      fontsize=26, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], y=1.04)
-        fig.text(0.5, 0.96, "How do business account top merchants compare to the overall member base?",
+                     color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+        fig.text(0.5, GEN_SUBTITLE_Y, "How do business account top merchants compare to the overall member base?",
                  ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
         plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/campaign/01_campaign_data.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/01_campaign_data.py
@@ -6,6 +6,34 @@
 # Uses DATASET_MONTHS from setup/09 for per-month normalization.
 # Guard: try/except for missing columns.
 
+# ---------------------------------------------------------------------------
+# SLIDE_MODE pruning for campaign section (default standard ~25 slides).
+# 22-29 is an 8-cell segment-cohort deep-dive; 30-36 is a 7-cell responder
+# demographic breakdown. Both valuable for a full analyst audit but
+# duplicative noise for a client exec review. 'deep' runs everything.
+# ---------------------------------------------------------------------------
+import os as _os_mode
+_SLIDE_MODE = _os_mode.environ.get('SLIDE_MODE', 'standard').lower()
+_PRUNE = {
+    'standard': [
+        '22_', '23_', '24_', '25_', '26_', '27_', '28_', '29_',
+        '30_', '31_', '32_', '33_', '34_', '35_', '36_',
+        '38_', '41_', '43_',
+    ],
+    'minimal': [
+        '03_', '05_', '07_', '09_', '10_', '11_', '12_', '13_',
+        '14_', '15_', '16_', '18_', '19_', '20_', '21_',
+        '22_', '23_', '24_', '25_', '26_', '27_', '28_', '29_',
+        '30_', '31_', '32_', '33_', '34_', '35_', '36_',
+        '38_', '40_', '41_', '43_',
+    ],
+    'deep': [],
+}
+SKIP_SCRIPT_PATTERNS = _PRUNE.get(_SLIDE_MODE, [])
+if SKIP_SCRIPT_PATTERNS:
+    print(f"    SLIDE_MODE={_SLIDE_MODE}: pruning {len(SKIP_SCRIPT_PATTERNS)} "
+          f"campaign cell patterns for deck size control")
+
 try:
     # Identify available mail/resp columns
     rewards_cols = [c.strip() for c in rewards_df.columns]

--- a/01_Analysis/00-Scripts/analytics/campaign/11_cohort_lift_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/11_cohort_lift_kpi.py
@@ -76,8 +76,8 @@ else:
 
     fig.suptitle("ARS Cohort Lift Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.97, f"Difference-in-Differences methodology  ({DATASET_LABEL})",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, f"Difference-in-Differences methodology  ({DATASET_LABEL})",
              ha='center', fontsize=14, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/campaign/17_swipe_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/17_swipe_kpi.py
@@ -81,8 +81,8 @@ else:
 
     fig.suptitle("Campaign Swipe Behavior Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.97, f"Monthly card usage metrics  |  {DATASET_LABEL}",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, f"Monthly card usage metrics  |  {DATASET_LABEL}",
              ha='center', fontsize=14, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/campaign/34_responder_account_age_chart.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/34_responder_account_age_chart.py
@@ -33,7 +33,9 @@ else:
     # =================================================================
     # LEFT: Response Rate by Account Age (hero)
     # =================================================================
-    bars = ax1.bar(x, resp_age_summary['response_rate'], width=0.6,
+    # Wider bars (0.78 instead of 0.6) so the in-bar count text doesn't
+    # overflow the column edges -- reported visual bug from 4/27 deck review.
+    bars = ax1.bar(x, resp_age_summary['response_rate'], width=0.78,
                    color=_RESP_COLOR, edgecolor='white', linewidth=0.5, alpha=0.85)
 
     _max_idx = resp_age_summary['response_rate'].idxmax()
@@ -43,6 +45,9 @@ else:
             bar.set_color(_ACCENT)
             bar.set_alpha(1.0)
 
+    # Combine rate% and count into ONE label above the bar so we don't have
+    # to fit white "n=X mailed" text inside narrow columns. The mailed count
+    # is essential context but doesn't need to live inside the bar.
     for i, (bar, rate, mailed) in enumerate(zip(bars,
                                                   resp_age_summary['response_rate'],
                                                   resp_age_summary['mailed'])):
@@ -50,9 +55,18 @@ else:
                  f'{rate:.1f}%', ha='center', va='bottom', fontsize=14,
                  fontweight='bold',
                  color=_ACCENT if i == _max_pos else _RESP_COLOR)
-        ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() / 2,
-                 f'{int(mailed):,}\nmailed', ha='center', va='center', fontsize=14,
-                 color='white', fontweight='bold')
+        # Count label: white inside the bar IF the bar is tall enough, else
+        # gray below the bar baseline so it never bleeds off-edge. Switch
+        # threshold at 1.5% absolute response rate (most decks have rates
+        # in the 0.5-5% range).
+        if bar.get_height() >= 1.5:
+            ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() / 2,
+                     f'{int(mailed):,}', ha='center', va='center', fontsize=11,
+                     color='white', fontweight='bold')
+        else:
+            ax1.text(bar.get_x() + bar.get_width() / 2, -0.18,
+                     f'n={int(mailed):,}', ha='center', va='top', fontsize=10,
+                     color=_MUTED, fontweight='bold')
 
     _overall_rate = resp_age_summary['responded'].sum() / resp_age_summary['mailed'].sum() * 100
     ax1.axhline(_overall_rate, color=_MUTED, linewidth=1.5, linestyle='--', zorder=2)

--- a/01_Analysis/00-Scripts/analytics/campaign/36_responder_holder_age_chart.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/36_responder_holder_age_chart.py
@@ -33,7 +33,9 @@ else:
     # =================================================================
     # LEFT: Response Rate by Holder Age (hero)
     # =================================================================
-    bars = ax1.bar(x, holder_age_summary['response_rate'], width=0.6,
+    # Wider bars + adaptive label placement (mirrors cell 34 fix from the
+    # 4/27 deck review -- skinny columns + white text bleeding off-edges)
+    bars = ax1.bar(x, holder_age_summary['response_rate'], width=0.78,
                    color=_INFO, edgecolor='white', linewidth=0.5, alpha=0.85)
 
     _max_idx = holder_age_summary['response_rate'].idxmax()
@@ -50,9 +52,14 @@ else:
                  f'{rate:.1f}%', ha='center', va='bottom', fontsize=14,
                  fontweight='bold',
                  color=_ACCENT if i == _max_pos else _INFO)
-        ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() / 2,
-                 f'{int(mailed):,}\nmailed', ha='center', va='center', fontsize=14,
-                 color='white', fontweight='bold')
+        if bar.get_height() >= 1.5:
+            ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() / 2,
+                     f'{int(mailed):,}', ha='center', va='center', fontsize=11,
+                     color='white', fontweight='bold')
+        else:
+            ax1.text(bar.get_x() + bar.get_width() / 2, -0.18,
+                     f'n={int(mailed):,}', ha='center', va='top', fontsize=10,
+                     color=_MUTED, fontweight='bold')
 
     _overall_rate = holder_age_summary['responded'].sum() / holder_age_summary['mailed'].sum() * 100
     ax1.axhline(_overall_rate, color=_MUTED, linewidth=1.5, linestyle='--', zorder=2)

--- a/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
+++ b/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
@@ -11,7 +11,45 @@
 # Everything else is automatic.
 # ===========================================================================
 
+import os
 import pandas as pd
+
+# ---------------------------------------------------------------------------
+# SLIDE_MODE: controls deck size for competition section.
+#   'standard' (default) -- core 7/8/9/11/13/15/16/31/32/33 story  (~25 slides)
+#   'deep'               -- full section including all segment/wallet/banks-only
+#                            parallel views (~89 slides)
+#   'minimal'            -- just top-10 + category donut + momentum (~10 slides)
+#
+# Configured via SLIDE_MODE env var so the UI can expose it per-client.
+# Ignored when the section doesn't have a curated prune list defined here.
+# ---------------------------------------------------------------------------
+SLIDE_MODE = os.environ.get('SLIDE_MODE', 'standard').lower()
+
+# Competition-section prune lists. Prefix match on script stem. The 60-series
+# is two PARALLEL recuts of cells 07/08/09/65 (banks-only + core-competition
+# minus ecosystems). 66/67 are ecosystem deep-dives. 70 is a head-to-head
+# comparison chart. All valuable but duplicative for a client exec review.
+# 18, 20-28 are segment-by-segment slices -- kept in 'deep' only.
+_PRUNE_BY_MODE = {
+    'standard': [
+        '18_', '20_', '21_', '22_', '23_', '24_', '26_', '28_',
+        '60_', '61_', '62_', '65_', '66_', '67_', '70_',
+    ],
+    'minimal': [
+        '10_', '11_', '12_', '13_', '14_', '17_', '18_', '19_',
+        '20_', '21_', '22_', '23_', '24_', '25_', '26_', '27_',
+        '28_', '29_', '30_', '40_', '41_',
+        '60_', '61_', '62_', '65_', '66_', '67_', '68_', '70_',
+    ],
+    'deep': [],
+}
+SKIP_SCRIPT_PATTERNS = _PRUNE_BY_MODE.get(SLIDE_MODE, [])
+if SKIP_SCRIPT_PATTERNS:
+    print(f"    SLIDE_MODE={SLIDE_MODE}: pruning {len(SKIP_SCRIPT_PATTERNS)} "
+          f"competition cell patterns to control deck size")
+elif SLIDE_MODE == 'deep':
+    print(f"    SLIDE_MODE=deep: running ALL competition cells (~89 slides)")
 
 # ===========================================================================
 # SECTION A: UNIVERSAL COMPETITORS (do not edit)

--- a/01_Analysis/00-Scripts/analytics/competition/02_competitor_detection.py
+++ b/01_Analysis/00-Scripts/analytics/competition/02_competitor_detection.py
@@ -108,7 +108,7 @@ else:
     fig, axes = plt.subplots(1, 4, figsize=(20, 4.5))
     fig.patch.set_facecolor('#FFFFFF')
     fig.suptitle("Competitor Detection Results",
-                 fontsize=26, fontweight='bold', color=GEN_COLORS['dark_text'], y=1.04)
+                 fontsize=26, fontweight='bold', color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
     for ax, (value, label, color) in zip(axes, kpis):
         ax.set_xlim(0, 1)

--- a/01_Analysis/00-Scripts/analytics/competition/07_kpi_dashboard.py
+++ b/01_Analysis/00-Scripts/analytics/competition/07_kpi_dashboard.py
@@ -63,7 +63,7 @@ if len(all_competitor_data) > 0:
     fig.suptitle("Competitive Exposure at a Glance",
                  fontsize=28, fontweight='bold',
                  color=GEN_COLORS['dark_text'],
-                 y=1.04)
+                 y=GEN_TITLE_Y)
 
     plt.tight_layout()
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/competition/35_competitor_count_distribution.py
+++ b/01_Analysis/00-Scripts/analytics/competition/35_competitor_count_distribution.py
@@ -1,0 +1,220 @@
+# ===========================================================================
+# COMPETITOR COUNT DISTRIBUTION: how many competitors does each account use?
+# ===========================================================================
+# Mirrors financial_services/13_category_combinations style of analysis but
+# at the COMPETITOR-COUNT level instead of category co-occurrence:
+#
+#   How many accounts use 1 competitor? 2-3? 4-5? 6-7? More?
+#
+# Same intent as the user's existing financial-services-categories analysis
+# applied to the competition section. Excludes wallets/BNPL/P2P by default
+# since those are payment ecosystems, not banking competitors -- the
+# question is "how many ALTERNATIVE BANKS are members shopping at?".
+#
+# Toggle COMPETITOR_COUNT_INCLUDE_ECOSYSTEMS = True if you want a parallel
+# all-competitors view that includes ecosystems.
+#
+# Inputs (from competition/02_competitor_detection):
+#   competitor_txns          DataFrame with primary_account_num, competitor_match,
+#                            competitor_category
+#   BANK_CATEGORIES          list of category keys excluding wallets/p2p/bnpl
+#   GEN_COLORS, member_word, MEMBER_NOUN_PLURAL  from general theme
+# ===========================================================================
+
+import pandas as _pd_cc
+import numpy as _np_cc
+import matplotlib.pyplot as _plt_cc
+from matplotlib.patches import FancyBboxPatch as _FancyBox
+
+# Optional toggle (defaults to bank-only count)
+COMPETITOR_COUNT_INCLUDE_ECOSYSTEMS = bool(globals().get(
+    "COMPETITOR_COUNT_INCLUDE_ECOSYSTEMS", False))
+
+# Defensive bootstrap -- same pattern as the 60-series cells.
+_BOOT_OK = True
+try:
+    competitor_txns
+except NameError:
+    print("    Skipping cell 35 -- competitor_txns missing. Run cell 02 first.")
+    _BOOT_OK = False
+
+try:
+    BANK_CATEGORIES
+except NameError:
+    try:
+        BANK_CATEGORIES = [k for k in COMPETITOR_MERCHANTS
+                           if k not in ('wallets', 'p2p', 'bnpl')]
+    except NameError:
+        BANK_CATEGORIES = []
+
+# Colors / language fallback
+_GEN = globals().get('GEN_COLORS', {
+    'accent': '#E63946', 'info': '#457B9D', 'success': '#2EC4B6',
+    'warning': '#FF9F1C', 'dark_text': '#1B2A4A', 'muted': '#6C757D',
+    'grid': '#E0E0E0',
+})
+_M_WORD_PL = globals().get('MEMBER_NOUN_PLURAL', 'members')
+_M_WORD_TI = globals().get('MEMBER_NOUN_TITLE_PL', 'Members')
+
+if _BOOT_OK:
+    # ---------------------------------------------------------------
+    # Filter the txn set: bank-categories only (or all, per toggle)
+    # ---------------------------------------------------------------
+    if COMPETITOR_COUNT_INCLUDE_ECOSYSTEMS:
+        _ctx = competitor_txns.copy()
+        _scope_label = "All competitors (banks + payment ecosystems)"
+    else:
+        _ctx = competitor_txns[
+            competitor_txns['competitor_category'].isin(BANK_CATEGORIES)
+        ].copy()
+        _scope_label = "Banking competitors only (wallets/BNPL/P2P excluded)"
+
+    if len(_ctx) == 0:
+        print("    No competitor txns in scope -- skipping cell 35.")
+    else:
+        # ---------------------------------------------------------------
+        # Per-account distinct competitor count
+        # ---------------------------------------------------------------
+        _per_acct = (
+            _ctx.groupby('primary_account_num')['competitor_match']
+            .nunique()
+            .reset_index(name='n_competitors')
+        )
+
+        # Bucket per the user spec: 1, 2-3, 4-5, 6-7, 8+
+        def _bucket(n):
+            if n == 1:
+                return '1'
+            if 2 <= n <= 3:
+                return '2-3'
+            if 4 <= n <= 5:
+                return '4-5'
+            if 6 <= n <= 7:
+                return '6-7'
+            return '8+'
+        _per_acct['bucket'] = _per_acct['n_competitors'].apply(_bucket)
+
+        _bucket_order = ['1', '2-3', '4-5', '6-7', '8+']
+        _by_bucket = (
+            _per_acct.groupby('bucket').size().reindex(_bucket_order, fill_value=0)
+        )
+        _total_competitor_accts = int(_by_bucket.sum())
+        _by_bucket_pct = (_by_bucket / max(_total_competitor_accts, 1)) * 100
+
+        # Total portfolio for the no-competitor pct
+        try:
+            _total_portfolio = combined_df['primary_account_num'].nunique()
+        except Exception:
+            _total_portfolio = _total_competitor_accts
+        _no_competitor = max(_total_portfolio - _total_competitor_accts, 0)
+        _no_competitor_pct = _no_competitor / max(_total_portfolio, 1) * 100
+
+        # ---------------------------------------------------------------
+        # Visual: 2-panel
+        #   Left: bar chart of bucketed distribution
+        #   Right: KPI cards summarizing single-vs-multi competitor mix
+        # ---------------------------------------------------------------
+        fig, (ax1, ax2) = _plt_cc.subplots(
+            1, 2, figsize=(20, 7), gridspec_kw={'width_ratios': [3, 2]},
+        )
+
+        # --- LEFT: Bucket bar ---
+        _bar_colors = [
+            _GEN['info'], _GEN['info'], _GEN['warning'], _GEN['accent'], _GEN['accent']
+        ]
+        _bars = ax1.bar(
+            range(len(_bucket_order)), _by_bucket.values,
+            color=_bar_colors, edgecolor='white', linewidth=1.2, width=0.78,
+        )
+        for i, (bar, n, pct) in enumerate(zip(_bars, _by_bucket.values, _by_bucket_pct.values)):
+            ax1.text(bar.get_x() + bar.get_width() / 2,
+                     bar.get_height() + max(_by_bucket.max() * 0.02, 1),
+                     f"{int(n):,}\n({pct:.1f}%)",
+                     ha='center', va='bottom', fontsize=13,
+                     fontweight='bold', color=_GEN['dark_text'])
+
+        ax1.set_xticks(range(len(_bucket_order)))
+        ax1.set_xticklabels(_bucket_order, fontsize=14, fontweight='bold')
+        ax1.set_xlabel(f"Number of distinct competitors used per {globals().get('MEMBER_NOUN', 'member')}",
+                       fontsize=13, fontweight='bold', labelpad=10)
+        ax1.set_ylabel(f"{_M_WORD_TI} ({_M_WORD_PL})", fontsize=13, fontweight='bold')
+        ax1.set_title("Competitor-Count Distribution",
+                      fontsize=20, fontweight='bold',
+                      color=_GEN['dark_text'], loc='left', pad=10)
+        ax1.spines['top'].set_visible(False)
+        ax1.spines['right'].set_visible(False)
+        ax1.yaxis.grid(True, color=_GEN['grid'], linewidth=0.5, alpha=0.7)
+        ax1.set_axisbelow(True)
+        ax1.set_ylim(0, _by_bucket.max() * 1.20 if _by_bucket.max() > 0 else 1)
+
+        # --- RIGHT: KPI cards ---
+        _single = int(_by_bucket.get('1', 0))
+        _multi = _total_competitor_accts - _single
+        _heavy = int(_by_bucket.get('6-7', 0)) + int(_by_bucket.get('8+', 0))
+        _kpis = [
+            (f"{_no_competitor:,}",
+             f"{_M_WORD_TI} with NO\ncompetitor activity",
+             f"{_no_competitor_pct:.1f}% of portfolio",
+             _GEN['success']),
+            (f"{_single:,}",
+             f"Use exactly 1\ncompetitor",
+             f"{(_single / max(_total_portfolio, 1) * 100):.1f}% of portfolio",
+             _GEN['info']),
+            (f"{_multi:,}",
+             f"Use 2+ competitors\n(actively shopping)",
+             f"{(_multi / max(_total_portfolio, 1) * 100):.1f}% of portfolio",
+             _GEN['warning']),
+            (f"{_heavy:,}",
+             f"Use 6+ competitors\n(deeply diversified)",
+             f"{(_heavy / max(_total_portfolio, 1) * 100):.1f}% of portfolio",
+             _GEN['accent']),
+        ]
+        ax2.set_xlim(0, 1)
+        ax2.set_ylim(0, 1)
+        ax2.axis('off')
+        for i, (val, label, sub, color) in enumerate(_kpis):
+            y0 = 0.78 - i * 0.22
+            card = _FancyBox((0.04, y0), 0.92, 0.18,
+                             boxstyle="round,pad=0.02",
+                             facecolor=color, alpha=0.10,
+                             edgecolor=color, linewidth=2,
+                             transform=ax2.transAxes)
+            ax2.add_patch(card)
+            ax2.text(0.10, y0 + 0.10, val, transform=ax2.transAxes,
+                     fontsize=28, fontweight='bold', color=color, va='center')
+            ax2.text(0.50, y0 + 0.13, label, transform=ax2.transAxes,
+                     fontsize=12, fontweight='bold',
+                     color=_GEN['dark_text'], va='center', ha='left')
+            ax2.text(0.50, y0 + 0.04, sub, transform=ax2.transAxes,
+                     fontsize=10.5, color=_GEN['muted'], va='center', ha='left')
+
+        # Title (use universal layout constants)
+        _title_y = globals().get('GEN_TITLE_Y', 0.97)
+        _subtitle_y = globals().get('GEN_SUBTITLE_Y', 0.92)
+        _top_pad = globals().get('GEN_TOP_PAD', 0.85)
+        fig.suptitle(f"How Many Competitors Do {_M_WORD_TI} Use?",
+                     fontsize=24, fontweight='bold',
+                     color=_GEN['dark_text'], y=_title_y)
+        fig.text(0.5, _subtitle_y, _scope_label,
+                 ha='center', fontsize=12, color=_GEN['muted'], style='italic')
+        _plt_cc.subplots_adjust(top=_top_pad, bottom=0.13, left=0.07, right=0.97, wspace=0.25)
+        _plt_cc.show()
+
+        # ---------------------------------------------------------------
+        # Console summary
+        # ---------------------------------------------------------------
+        print()
+        print("=" * 60)
+        print(f"  COMPETITOR-COUNT DISTRIBUTION  ({_scope_label})")
+        print("=" * 60)
+        print(f"  Total {_M_WORD_PL} in portfolio:        {_total_portfolio:>9,}")
+        print(f"  {_M_WORD_TI} with NO competitor activity: {_no_competitor:>9,}  ({_no_competitor_pct:.1f}%)")
+        print(f"  {_M_WORD_TI} with competitor activity:    {_total_competitor_accts:>9,}  "
+              f"({(100 - _no_competitor_pct):.1f}%)")
+        print()
+        print(f"  Of those with competitor activity:")
+        for bucket in _bucket_order:
+            n = int(_by_bucket.get(bucket, 0))
+            pct = _by_bucket_pct.get(bucket, 0)
+            print(f"    {bucket:<5s} competitors:  {n:>8,}  ({pct:.1f}%)")
+        print("=" * 60)

--- a/01_Analysis/00-Scripts/analytics/competition/60_banks_only_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/competition/60_banks_only_kpi.py
@@ -137,8 +137,8 @@ else:
 
         fig.suptitle("Competitive Exposure — Banks Only",
                      fontsize=30, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], y=1.04)
-        fig.text(0.5, 0.97,
+                     color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+        fig.text(0.5, GEN_SUBTITLE_Y,
                  f"Excludes wallets / P2P / BNPL ({_eco_txns:,} txns, {_eco_pct:.1f}% of competitor activity)",
                  ha='center', fontsize=14, color=GEN_COLORS['muted'], style='italic')
 

--- a/01_Analysis/00-Scripts/analytics/competition/60_core_competition_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/competition/60_core_competition_kpi.py
@@ -60,8 +60,8 @@ else:
 
     fig.suptitle("Competitive Exposure — Banks + BNPL",
                  fontsize=30, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.97, SCOPE_NOTE,
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, SCOPE_NOTE,
              ha='center', fontsize=14, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/competition/67_core_bnpl_threats.py
+++ b/01_Analysis/00-Scripts/analytics/competition/67_core_bnpl_threats.py
@@ -82,7 +82,7 @@ else:
                 ha='center', va='center', linespacing=1.4)
     fig0.suptitle("BNPL Threat Snapshot",
                   fontsize=26, fontweight='bold',
-                  color=GEN_COLORS['dark_text'], y=1.04)
+                  color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
     fig0.text(0.5, 0.97, SCOPE_NOTE,
               ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/competition/69_cu_bank_audit.py
+++ b/01_Analysis/00-Scripts/analytics/competition/69_cu_bank_audit.py
@@ -1,0 +1,116 @@
+# ===========================================================================
+# CU / LOCAL BANK AUDIT -- verify every configured competitor is tagged
+# ===========================================================================
+# Specifically addresses the ``two credit unions, two local banks'' problem
+# where CoastHills (client 1776) should have surfaced 7-8 CUs and 6-7 local
+# banks but the slide reported only two of each. Root cause was carrier
+# prefix noise ("ACH CREDIT ...") preventing prefix-match in
+# tag_competitors. After the txn_setup/06 strip-carrier-noise fix, this
+# diagnostic is what confirms each client's CU/bank list is fully captured.
+#
+# For every configured credit_unions + local_banks pattern, prints:
+#   - Whether any tagged transaction used it
+#   - The tagged txn count + account count
+#   - Top 5 unmatched merchants containing CREDIT UNION / BANK / FCU that
+#     DIDN'T tag (candidates for new rules in client config)
+#
+# Assumes competitor_txns, combined_df, COMPETITOR_MERCHANTS, CLIENT_CONFIGS
+# are in globals.
+# ===========================================================================
+
+import os as _os_audit
+import pandas as _pd_audit
+
+print("=" * 72)
+print("CU / LOCAL BANK AUDIT  --  CLIENT:",
+      globals().get("CLIENT_ID", _os_audit.environ.get("CLIENT_ID", "?")))
+print("=" * 72)
+
+_client_id = globals().get("CLIENT_ID", _os_audit.environ.get("CLIENT_ID", ""))
+_cfg = CLIENT_CONFIGS.get(_client_id, {}) if "CLIENT_CONFIGS" in dir() else {}
+_cu_patterns    = _cfg.get("credit_unions", [])
+_bank_patterns  = _cfg.get("local_banks", [])
+
+# ---------------------------------------------------------------------------
+# Per-pattern audit
+# ---------------------------------------------------------------------------
+def _audit_patterns(label, patterns):
+    print()
+    print(f"-- {label} --  ({len(patterns)} configured)")
+    if not patterns:
+        print("  (none configured for this client)")
+        return 0, 0
+    cu_df = competitor_txns.copy() if "competitor_txns" in dir() else _pd_audit.DataFrame()
+    if cu_df.empty:
+        print("  (competitor_txns is empty -- run cell 02 first)")
+        return 0, 0
+    hit_count = 0
+    total_txns = 0
+    total_accts = set()
+    for pat in patterns:
+        pat_upper = pat.upper().strip()
+        # Match merchants whose normalized name STARTS with the pattern
+        m = cu_df["merchant_consolidated"].astype(str).str.upper().str.startswith(pat_upper)
+        n_txn = int(m.sum())
+        n_acct = cu_df.loc[m, "primary_account_num"].nunique() if n_txn else 0
+        if n_txn:
+            hit_count += 1
+            total_txns += n_txn
+            total_accts.update(cu_df.loc[m, "primary_account_num"].unique())
+            mark = "OK  "
+        else:
+            mark = "MISS"
+        print(f"    {mark}  {pat:<35s}  {n_txn:>8,} txns  {n_acct:>6,} accts")
+    print(f"  Summary: {hit_count}/{len(patterns)} patterns tagged "
+          f"({total_txns:,} txns, {len(total_accts):,} unique accts)")
+    return hit_count, len(patterns)
+
+_cu_hit,   _cu_total   = _audit_patterns("CREDIT UNIONS",  _cu_patterns)
+_bank_hit, _bank_total = _audit_patterns("LOCAL BANKS",    _bank_patterns)
+
+# ---------------------------------------------------------------------------
+# Unmatched financial-institution merchants (candidates to add)
+# ---------------------------------------------------------------------------
+print()
+print("-- TOP 30 UNMATCHED FI-LIKE MERCHANTS --")
+print("(Candidates to add to CLIENT_CONFIGS[credit_unions/local_banks])")
+if "combined_df" in dir() and "competitor_category" in combined_df.columns:
+    _untagged = combined_df[combined_df["competitor_category"].isna()]
+    if len(_untagged):
+        _m_upper = _untagged["merchant_consolidated"].astype(str).str.upper()
+        _fi_mask = _m_upper.str.contains(
+            r"CREDIT UNION|\bFCU\b|\bCU\b|FEDERAL CREDIT|BANK",
+            regex=True, na=False,
+        )
+        _fi_hits = _untagged[_fi_mask]
+        if len(_fi_hits):
+            _top = (_fi_hits.groupby("merchant_consolidated")
+                    .agg(txns=("primary_account_num", "count"),
+                         accts=("primary_account_num", "nunique"))
+                    .sort_values("txns", ascending=False)
+                    .head(30))
+            for name, row in _top.iterrows():
+                print(f"    {int(row['txns']):>8,} txns  {int(row['accts']):>5,} accts  {name}")
+        else:
+            print("    (no untagged FI-like merchants -- good coverage)")
+    else:
+        print("    (no untagged transactions)")
+else:
+    print("    (combined_df or competitor_category not in namespace)")
+
+# ---------------------------------------------------------------------------
+# Headline diagnosis
+# ---------------------------------------------------------------------------
+print()
+print("-" * 72)
+if _cu_total and _cu_hit < _cu_total:
+    print(f"  WARNING: only {_cu_hit} of {_cu_total} configured CUs captured.")
+    print(f"  Check: (a) carrier prefix stripping in txn_setup/06;")
+    print(f"         (b) merchant name variants under different spellings.")
+elif _cu_total:
+    print(f"  CUs: {_cu_hit}/{_cu_total} fully captured.")
+if _bank_total and _bank_hit < _bank_total:
+    print(f"  WARNING: only {_bank_hit} of {_bank_total} configured local banks captured.")
+elif _bank_total:
+    print(f"  Local banks: {_bank_hit}/{_bank_total} fully captured.")
+print("=" * 72)

--- a/01_Analysis/00-Scripts/analytics/competition/70_banking_vs_ecosystems.py
+++ b/01_Analysis/00-Scripts/analytics/competition/70_banking_vs_ecosystems.py
@@ -98,7 +98,7 @@ for ax, (value, label, color) in zip(axes1, kpis):
             ha='center', va='center', linespacing=1.4)
 fig1.suptitle("Banking vs Digital Ecosystems — Account Reach Head-to-Head",
               fontsize=26, fontweight='bold',
-              color=GEN_COLORS['dark_text'], y=1.04)
+              color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 sub = f"Ecosystem = wallets + P2P.  Banks + BNPL includes Affirm/Klarna/Afterpay."
 if spotlight and top_bank:
     ratio = spotlight_reach / max(top_bank_reach, 0.01)

--- a/01_Analysis/00-Scripts/analytics/cross_cohort/02_cohort_kpi_panel.py
+++ b/01_Analysis/00-Scripts/analytics/cross_cohort/02_cohort_kpi_panel.py
@@ -154,7 +154,7 @@ else:
 
     fig.suptitle('ARS Performance by Acquisition Channel',
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.05)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
     fig.text(0.5, 0.98,
              'Scope: accounts mailed >=1 ARS offer.  Each card: ICS value | Non-ICS value.',
              ha='center', fontsize=12, color=GEN_COLORS['muted'], style='italic')

--- a/01_Analysis/00-Scripts/analytics/engagement/02_migration_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/engagement/02_migration_kpi.py
@@ -85,8 +85,8 @@ else:
 
     fig.suptitle("Engagement Migration Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.97, f"Are members becoming more or less engaged?  |  {DATASET_LABEL}",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, f"Are members becoming more or less engaged?  |  {DATASET_LABEL}",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/executive/05_action_roadmap.py
+++ b/01_Analysis/00-Scripts/analytics/executive/05_action_roadmap.py
@@ -282,20 +282,36 @@ _folder_counts = {
     'interchange': 10, 'rege_overdraft': 10, 'payroll': 10,
     'relationship': 10, 'segment_evolution': 8, 'executive': 5,
 }
-# Try to get actual counts
+# Folder/cell totals: prefer the baked-in fallback so this cell never crashes
+# on a machine without the legacy /private/tmp/txn-visual-test scratch dir
+# (that path was Mac-dev leftovers -- broke every Windows run as WinError 3).
+# If the script's own parent directory is introspectable, use that to derive
+# a current cell count; otherwise use _folder_counts as the source of truth.
+_actual_total = sum(_folder_counts.values())
+_folder_count = len(_folder_counts)
 try:
     import os
-    _actual_total = 0
-    _base = '/private/tmp/txn-visual-test'
-    for _folder in os.listdir(_base):
-        _fpath = os.path.join(_base, _folder)
-        if os.path.isdir(_fpath):
-            _actual_total += len([
-                f for f in os.listdir(_fpath)
-                if not f.startswith('.') and os.path.isfile(os.path.join(_fpath, f))
-            ])
+    _script_path = globals().get("__file__")
+    if _script_path:
+        _analytics_root = os.path.dirname(os.path.dirname(_script_path))
+        if os.path.isdir(_analytics_root):
+            _live_folders = [
+                d for d in os.listdir(_analytics_root)
+                if os.path.isdir(os.path.join(_analytics_root, d))
+                and not d.startswith(".") and not d.startswith("__")
+            ]
+            _live_total = 0
+            for _fname in _live_folders:
+                _fpath = os.path.join(_analytics_root, _fname)
+                _live_total += len([
+                    f for f in os.listdir(_fpath)
+                    if f.endswith(".py") and not f.startswith("__")
+                ])
+            if _live_total > 0:
+                _actual_total = _live_total
+                _folder_count = len(_live_folders)
 except Exception:
-    _actual_total = sum(_folder_counts.values())
+    pass
 
 print(f"\n{'='*70}")
 print(f"  ACTION ROADMAP SUMMARY")
@@ -306,7 +322,7 @@ print(f"  Strategic (90-365 days):  {_strategic_ct} actions")
 print(f"  Total actions:            {_quick_ct + _medium_ct + _strategic_ct}")
 print(f"{'='*70}")
 
-print(f"\n    Full analysis available across {len([d for d in os.listdir(_base) if os.path.isdir(os.path.join(_base, d))])} folders, "
+print(f"\n    Full analysis available across {_folder_count} folders, "
       f"{_actual_total} total cells.")
 
 print(f"\n    INSIGHT: Quick wins focus on immediate outreach and process improvements "

--- a/01_Analysis/00-Scripts/analytics/financial_services/06_kpi_dashboard.py
+++ b/01_Analysis/00-Scripts/analytics/financial_services/06_kpi_dashboard.py
@@ -42,7 +42,7 @@ for ax, (value, label, color) in zip(axes, kpis):
 
 fig.suptitle("Financial Services Leakage at a Glance",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/general/01_general_theme.py
+++ b/01_Analysis/00-Scripts/analytics/general/01_general_theme.py
@@ -165,3 +165,77 @@ print("General portfolio theme loaded.")
 print(f"  Palettes: {len(BRACKET_PALETTE)} bracket, {len(AGE_PALETTE)} age, {len(ENGAGE_PALETTE)} engagement, {len(ACCT_AGE_PALETTE)} account age, {len(SPEND_TIER_PALETTE)} spend tier, {len(SWIPE_PALETTE)} swipe")
 print(f"  Font base: {plt.rcParams['font.size']}pt bold")
 print(f"  DPI: {plt.rcParams['figure.dpi']}")
+
+
+# ===========================================================================
+# CLIENT TYPE + DYNAMIC LANGUAGE (CU = members, Bank = customers)
+# ===========================================================================
+# Auto-detect from CLIENT_NAME + CLIENT_TYPE override (per-client config or
+# env var). Every cell that displays "members" / "customers" should reference
+# these variables instead of hardcoding either word, so a single client config
+# entry flips the whole deck's terminology.
+#
+# Manual override: set CLIENT_TYPE = 'cu' | 'bank' env var, otherwise
+# heuristic on CLIENT_NAME (CU / Credit Union / FCU / Federal Credit -> 'cu').
+
+import os as _os_lang
+
+def _detect_client_type():
+    explicit = (_os_lang.environ.get('CLIENT_TYPE', '') or '').strip().lower()
+    if explicit in ('cu', 'credit_union', 'creditunion'):
+        return 'cu'
+    if explicit in ('bank',):
+        return 'bank'
+    name = (globals().get('CLIENT_NAME') or _os_lang.environ.get('CLIENT_NAME', '') or '').upper()
+    if 'CREDIT UNION' in name or 'FEDERAL CREDIT' in name or ' FCU' in name + ' ' or name.endswith(' CU') or ' CU ' in f' {name} ':
+        return 'cu'
+    return 'bank'
+
+CLIENT_TYPE = _detect_client_type()
+
+# Singular + plural noun forms used in slide copy and chart annotations
+if CLIENT_TYPE == 'cu':
+    MEMBER_NOUN          = 'member'
+    MEMBER_NOUN_PLURAL   = 'members'
+    MEMBER_NOUN_TITLE    = 'Member'
+    MEMBER_NOUN_TITLE_PL = 'Members'
+    POSSESSIVE           = "the credit union's"
+    INSTITUTION_NOUN     = 'credit union'
+else:
+    MEMBER_NOUN          = 'customer'
+    MEMBER_NOUN_PLURAL   = 'customers'
+    MEMBER_NOUN_TITLE    = 'Customer'
+    MEMBER_NOUN_TITLE_PL = 'Customers'
+    POSSESSIVE           = "the bank's"
+    INSTITUTION_NOUN     = 'bank'
+
+
+def member_word(n=None, plural=None, title=False):
+    """Return ``member''/``members''/``customer''/``customers'' based on the
+    active CLIENT_TYPE. Pass n for auto-pluralization, or plural=True/False
+    explicitly. title=True returns the capitalized form."""
+    if n is not None:
+        plural = (n != 1)
+    if plural is None:
+        plural = True
+    if title:
+        return MEMBER_NOUN_TITLE_PL if plural else MEMBER_NOUN_TITLE
+    return MEMBER_NOUN_PLURAL if plural else MEMBER_NOUN
+
+
+# ===========================================================================
+# UNIVERSAL TITLE / SUBTITLE LAYOUT CONSTANTS
+# ===========================================================================
+# Many cells were placing fig.suptitle at y=1.04 (above the figure box)
+# with a fig.text subtitle at y=0.96 -- subtitle ended up inside the title's
+# whitespace, causing visual overlap. Use these constants instead so every
+# cell ends up with the same breathing room.
+#
+#     fig.suptitle("...", y=GEN_TITLE_Y)
+#     fig.text(0.5, GEN_SUBTITLE_Y, "subtitle...", ha='center', ...)
+#     plt.subplots_adjust(top=GEN_TOP_PAD)
+GEN_TITLE_Y    = 0.97
+GEN_SUBTITLE_Y = 0.92
+GEN_TOP_PAD    = 0.85
+
+print(f"  CLIENT_TYPE: {CLIENT_TYPE}  (terminology: {MEMBER_NOUN_PLURAL})")

--- a/01_Analysis/00-Scripts/analytics/general/01_general_theme.py
+++ b/01_Analysis/00-Scripts/analytics/general/01_general_theme.py
@@ -87,7 +87,9 @@ SPEND_TIER_PALETTE = {
 }
 SPEND_TIER_ORDER = ['Very High', 'High', 'Medium', 'Low']
 
-# Swipe category palette (default labels -- data cell auto-discovers actual values)
+# Swipe category palette (LEGACY 5-bucket -- kept for backward compatibility
+# with cells that still reference these names; new analyses should prefer
+# the ARS_SWIPE_* buckets defined immediately below).
 SWIPE_PALETTE = {
     'Very High': '#E63946',
     'High':      '#FF9F1C',
@@ -96,6 +98,121 @@ SWIPE_PALETTE = {
     'Inactive':  '#6C757D',
 }
 SWIPE_ORDER = ['Very High', 'High', 'Medium', 'Low', 'Inactive']
+
+# ---------------------------------------------------------------------------
+# ARS-standard swipe-volume segmentation (per user spec, 4/27 review)
+# ---------------------------------------------------------------------------
+# 7 buckets aligned to the ARS playbook -- monthly swipes per account.
+# Used as both 3-month rolling average and 12-month average so the deck
+# can show ``recent activity vs steady state'' side-by-side.
+ARS_SWIPE_BUCKETS = [
+    # (lower_inclusive, upper_inclusive_or_None, label)
+    (0,    0,    '<1 (Inactive)'),
+    (1,    5,    '1-5'),
+    (6,    10,   '6-10'),
+    (11,   15,   '11-15'),
+    (16,   20,   '16-20'),
+    (21,   25,   '21-25'),
+    (26,   None, '25+'),
+]
+ARS_SWIPE_ORDER = [b[2] for b in ARS_SWIPE_BUCKETS]
+ARS_SWIPE_PALETTE = {
+    '<1 (Inactive)': '#6C757D',   # gray
+    '1-5':           '#457B9D',   # steel blue
+    '6-10':          '#2EC4B6',   # teal
+    '11-15':         '#A8DADC',   # mint
+    '16-20':         '#FF9F1C',   # amber
+    '21-25':         '#F4A261',   # warm orange
+    '25+':           '#E63946',   # red
+}
+
+
+def bucket_swipes_per_month(n):
+    """Map a per-month-average swipe count to its ARS bucket label.
+    Accepts int/float (rounded to nearest int for bucketing). NaN -> first
+    bucket (treated as inactive). Use on a Series via .apply()."""
+    try:
+        if n is None:
+            return ARS_SWIPE_BUCKETS[0][2]
+        if isinstance(n, float) and (n != n):  # NaN check
+            return ARS_SWIPE_BUCKETS[0][2]
+        x = int(round(float(n)))
+    except (TypeError, ValueError):
+        return ARS_SWIPE_BUCKETS[0][2]
+    if x <= 0:
+        return ARS_SWIPE_BUCKETS[0][2]
+    for lo, hi, label in ARS_SWIPE_BUCKETS:
+        if hi is None:
+            if x >= lo:
+                return label
+        elif lo <= x <= hi:
+            return label
+    return ARS_SWIPE_BUCKETS[-1][2]
+
+
+def compute_swipe_segmentation(df, txn_type_col='transaction_type',
+                               acct_col='primary_account_num',
+                               month_col='year_month',
+                               window_months=3):
+    """Compute per-account swipe averages over a window and return a DataFrame
+    with one row per account containing:
+        avg_swipes_3m       (most recent ``window_months'' avg)
+        avg_swipes_12m      (full 12-month avg)
+        bucket_3m           ARS bucket label using avg_swipes_3m
+        bucket_12m          ARS bucket label using avg_swipes_12m
+
+    Counts only PIN / SIG transactions (debit-card swipes). Falls back to
+    counting ALL rows if transaction_type is missing.
+
+    Use this when you want the user-spec ``3-month rolling vs 12-month''
+    side-by-side view in a segmentation chart.
+    """
+    import pandas as _pd
+    if df is None or len(df) == 0:
+        return _pd.DataFrame(columns=[
+            acct_col, 'avg_swipes_3m', 'avg_swipes_12m',
+            'bucket_3m', 'bucket_12m',
+        ])
+
+    work = df
+    # Restrict to PIN/SIG transactions when txn_type_col is present.
+    if txn_type_col in work.columns:
+        _ttype = work[txn_type_col].astype(str).str.upper().str.strip()
+        _swipe_mask = _ttype.isin(['PIN', 'SIG', 'POS', 'DEBIT'])
+        if _swipe_mask.any():
+            work = work[_swipe_mask]
+
+    if month_col not in work.columns or acct_col not in work.columns:
+        return _pd.DataFrame(columns=[
+            acct_col, 'avg_swipes_3m', 'avg_swipes_12m',
+            'bucket_3m', 'bucket_12m',
+        ])
+
+    # Per-account, per-month txn count
+    monthly = (
+        work.groupby([acct_col, month_col]).size()
+        .reset_index(name='swipes')
+    )
+
+    # Most-recent N months for the 3m window
+    months_sorted = sorted(monthly[month_col].unique())
+    recent_months = months_sorted[-window_months:]
+
+    avg_3m = (
+        monthly[monthly[month_col].isin(recent_months)]
+        .groupby(acct_col)['swipes'].mean()
+        .reset_index().rename(columns={'swipes': 'avg_swipes_3m'})
+    )
+    avg_12m = (
+        monthly.groupby(acct_col)['swipes'].mean()
+        .reset_index().rename(columns={'swipes': 'avg_swipes_12m'})
+    )
+
+    out = avg_12m.merge(avg_3m, on=acct_col, how='left')
+    out['avg_swipes_3m'] = out['avg_swipes_3m'].fillna(0)
+    out['bucket_3m']  = out['avg_swipes_3m'].apply(bucket_swipes_per_month)
+    out['bucket_12m'] = out['avg_swipes_12m'].apply(bucket_swipes_per_month)
+    return out
 
 # ---------------------------------------------------------------------------
 # Matplotlib global theme

--- a/01_Analysis/00-Scripts/analytics/general/03_kpi_dashboard.py
+++ b/01_Analysis/00-Scripts/analytics/general/03_kpi_dashboard.py
@@ -40,7 +40,7 @@ for ax, (value, label, color) in zip(axes, kpis):
 
 fig.suptitle("Portfolio at a Glance",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/general/30_ars_swipe_segmentation.py
+++ b/01_Analysis/00-Scripts/analytics/general/30_ars_swipe_segmentation.py
@@ -1,0 +1,170 @@
+# ===========================================================================
+# ARS SWIPE SEGMENTATION: monthly swipes per account, 3-month vs 12-month
+# ===========================================================================
+# User spec from 4/27 deck review (issue #95):
+#   ``We have segmentation by spend and swipes. Need to align on ARS:
+#     <1 swipe/mo (Avg), 1-5, 6-10, 11-15, 16-20, 21-25, 25+
+#     These are 3-month average counts, and I'd like to see 12-month avgs.
+#     Active and declining is good, keep that.''
+#
+# Output:
+#   * Side-by-side bars: 3-month rolling avg bucket vs 12-month avg bucket.
+#     Same bucket -> stable. Lower 3m than 12m -> declining (yellow flag).
+#     Higher 3m than 12m -> active / growing (green flag).
+#   * Stable / Active / Declining KPI cards on the right.
+#
+# Inputs (from txn_setup):
+#   combined_df with primary_account_num, year_month, transaction_type
+# ===========================================================================
+
+import pandas as _pd_swipe
+import matplotlib.pyplot as _plt_swipe
+from matplotlib.patches import FancyBboxPatch as _FB
+
+# Defensive: only run if combined_df + helpers are present
+if 'combined_df' not in dir() or 'compute_swipe_segmentation' not in dir():
+    print("    Skipping ARS swipe segmentation -- combined_df or helper missing.")
+else:
+    _seg = compute_swipe_segmentation(combined_df)
+    if len(_seg) == 0:
+        print("    No swipe data available for ARS segmentation.")
+    else:
+        _GEN = globals().get('GEN_COLORS', {
+            'accent': '#E63946', 'info': '#457B9D', 'success': '#2EC4B6',
+            'warning': '#FF9F1C', 'dark_text': '#1B2A4A', 'muted': '#6C757D',
+            'grid': '#E0E0E0',
+        })
+        _PAL = globals().get('ARS_SWIPE_PALETTE', {})
+        _ORD = globals().get('ARS_SWIPE_ORDER', [])
+        _M_TI = globals().get('MEMBER_NOUN_TITLE_PL', 'Members')
+        _M_PL = globals().get('MEMBER_NOUN_PLURAL', 'members')
+
+        # Counts per bucket for both windows
+        _c3  = _seg['bucket_3m'].value_counts().reindex(_ORD, fill_value=0)
+        _c12 = _seg['bucket_12m'].value_counts().reindex(_ORD, fill_value=0)
+        _total = max(int(_c12.sum()), 1)
+
+        # Stable / Active / Declining flags: compare each account's 3m vs 12m
+        # bucket position in the ordered list. Higher index = more swipes.
+        _idx = {label: i for i, label in enumerate(_ORD)}
+        _seg['_3m_idx']  = _seg['bucket_3m'].map(_idx).fillna(0).astype(int)
+        _seg['_12m_idx'] = _seg['bucket_12m'].map(_idx).fillna(0).astype(int)
+        _stable    = int((_seg['_3m_idx'] == _seg['_12m_idx']).sum())
+        _active    = int((_seg['_3m_idx'] >  _seg['_12m_idx']).sum())
+        _declining = int((_seg['_3m_idx'] <  _seg['_12m_idx']).sum())
+
+        # ---------------------------------------------------------------
+        # Chart: side-by-side 3m vs 12m bars per bucket
+        # ---------------------------------------------------------------
+        fig, (ax1, ax2) = _plt_swipe.subplots(
+            1, 2, figsize=(20, 7),
+            gridspec_kw={'width_ratios': [3.5, 2]},
+        )
+
+        import numpy as _np_swipe
+        x = _np_swipe.arange(len(_ORD))
+        bar_w = 0.4
+        _bars12 = ax1.bar(x - bar_w / 2, _c12.values, bar_w,
+                          label='12-month avg',
+                          color=_GEN['info'], edgecolor='white', linewidth=1.0)
+        _bars3 = ax1.bar(x + bar_w / 2, _c3.values, bar_w,
+                         label='3-month avg (recent)',
+                         color=_GEN['accent'], edgecolor='white', linewidth=1.0)
+
+        for bar, n in zip(_bars12, _c12.values):
+            if n > 0:
+                ax1.text(bar.get_x() + bar.get_width() / 2,
+                         bar.get_height() + max(_c12.max() * 0.015, 1),
+                         f"{int(n):,}", ha='center', va='bottom', fontsize=10,
+                         fontweight='bold', color=_GEN['info'])
+        for bar, n in zip(_bars3, _c3.values):
+            if n > 0:
+                ax1.text(bar.get_x() + bar.get_width() / 2,
+                         bar.get_height() + max(_c3.max() * 0.015, 1),
+                         f"{int(n):,}", ha='center', va='bottom', fontsize=10,
+                         fontweight='bold', color=_GEN['accent'])
+
+        ax1.set_xticks(x)
+        ax1.set_xticklabels(_ORD, fontsize=12, fontweight='bold', rotation=0)
+        ax1.set_xlabel("Monthly swipes per account",
+                       fontsize=13, fontweight='bold', labelpad=8)
+        ax1.set_ylabel(f"{_M_TI}", fontsize=13, fontweight='bold')
+        ax1.set_title(f"ARS Swipe Segmentation -- 3-month vs 12-month avg",
+                      fontsize=18, fontweight='bold',
+                      color=_GEN['dark_text'], loc='left', pad=10)
+        ax1.legend(loc='upper right', fontsize=12, frameon=False)
+        ax1.spines['top'].set_visible(False)
+        ax1.spines['right'].set_visible(False)
+        ax1.yaxis.grid(True, color=_GEN['grid'], linewidth=0.5, alpha=0.7)
+        ax1.set_axisbelow(True)
+        _max_count = max(_c3.max(), _c12.max(), 1)
+        ax1.set_ylim(0, _max_count * 1.18)
+
+        # --- KPI cards: Stable / Active / Declining ---
+        _kpis = [
+            (f"{_stable:,}",
+             "Stable\n(3m bucket = 12m)",
+             f"{(_stable / _total * 100):.1f}% of {_M_PL}",
+             _GEN['info']),
+            (f"{_active:,}",
+             f"Active / Growing\n(3m higher than 12m)",
+             f"{(_active / _total * 100):.1f}% of {_M_PL}",
+             _GEN['success']),
+            (f"{_declining:,}",
+             f"Declining\n(3m lower than 12m)",
+             f"{(_declining / _total * 100):.1f}% of {_M_PL}",
+             _GEN['accent']),
+        ]
+        ax2.set_xlim(0, 1)
+        ax2.set_ylim(0, 1)
+        ax2.axis('off')
+        for i, (val, label, sub, color) in enumerate(_kpis):
+            y0 = 0.72 - i * 0.28
+            card = _FB((0.04, y0), 0.92, 0.22,
+                      boxstyle="round,pad=0.02",
+                      facecolor=color, alpha=0.10,
+                      edgecolor=color, linewidth=2,
+                      transform=ax2.transAxes)
+            ax2.add_patch(card)
+            ax2.text(0.10, y0 + 0.13, val, transform=ax2.transAxes,
+                     fontsize=30, fontweight='bold', color=color, va='center')
+            ax2.text(0.50, y0 + 0.16, label, transform=ax2.transAxes,
+                     fontsize=12, fontweight='bold',
+                     color=_GEN['dark_text'], va='center', ha='left')
+            ax2.text(0.50, y0 + 0.06, sub, transform=ax2.transAxes,
+                     fontsize=10.5, color=_GEN['muted'], va='center', ha='left')
+
+        _title_y = globals().get('GEN_TITLE_Y', 0.97)
+        _subtitle_y = globals().get('GEN_SUBTITLE_Y', 0.92)
+        _top_pad = globals().get('GEN_TOP_PAD', 0.85)
+        fig.suptitle(f"How active are {_M_PL} on their cards?",
+                     fontsize=22, fontweight='bold',
+                     color=_GEN['dark_text'], y=_title_y)
+        fig.text(0.5, _subtitle_y,
+                 "Recent vs steady state -- gaps between 3-month and 12-month "
+                 "averages reveal who is changing behavior",
+                 ha='center', fontsize=12, color=_GEN['muted'], style='italic')
+        _plt_swipe.subplots_adjust(top=_top_pad, bottom=0.13,
+                                   left=0.06, right=0.97, wspace=0.18)
+        _plt_swipe.show()
+
+        # ---------------------------------------------------------------
+        # Console summary
+        # ---------------------------------------------------------------
+        print()
+        print("=" * 64)
+        print(f"  ARS SWIPE SEGMENTATION  ({_total:,} {_M_PL})")
+        print("=" * 64)
+        print(f"  Bucket            3m count    12m count   3m %     12m %")
+        print(f"  ---------------- ----------  ----------  -------  -------")
+        for bucket in _ORD:
+            n3 = int(_c3.get(bucket, 0))
+            n12 = int(_c12.get(bucket, 0))
+            p3 = (n3 / _total) * 100
+            p12 = (n12 / _total) * 100
+            print(f"  {bucket:<16s} {n3:>10,}  {n12:>10,}  {p3:>5.1f}%   {p12:>5.1f}%")
+        print()
+        print(f"  Stable     (3m == 12m bucket): {_stable:>9,}  ({_stable / _total * 100:>5.1f}%)")
+        print(f"  Active     (3m  > 12m bucket): {_active:>9,}  ({_active / _total * 100:>5.1f}%)")
+        print(f"  Declining  (3m  < 12m bucket): {_declining:>9,}  ({_declining / _total * 100:>5.1f}%)")
+        print("=" * 64)

--- a/01_Analysis/00-Scripts/analytics/ics_acquisition/02_ics_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/ics_acquisition/02_ics_kpi.py
@@ -74,8 +74,8 @@ else:
 
     fig.suptitle("ICS Account Acquisition Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.97, f"{DATASET_LABEL}  ({DATASET_MONTHS} months)",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, f"{DATASET_LABEL}  ({DATASET_MONTHS} months)",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/ics_acquisition/03_ics_channel_comparison.py
+++ b/01_Analysis/00-Scripts/analytics/ics_acquisition/03_ics_channel_comparison.py
@@ -43,8 +43,8 @@ else:
 
     fig.suptitle("ICS Acquisition Channel Comparison",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96,
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y,
              f"How do referral and direct mail accounts compare?  ({DATASET_LABEL}, {DATASET_MONTHS} mo)",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 

--- a/01_Analysis/00-Scripts/analytics/ics_acquisition/04_ics_merchant_preferences.py
+++ b/01_Analysis/00-Scripts/analytics/ics_acquisition/04_ics_merchant_preferences.py
@@ -59,8 +59,8 @@ else:
 
     fig.suptitle("ICS Merchant Preferences by Channel",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96,
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y,
              f"Do referral and direct mail members shop at different merchants?  ({DATASET_LABEL})",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 

--- a/01_Analysis/00-Scripts/analytics/ics_acquisition/09_ics_vs_portfolio.py
+++ b/01_Analysis/00-Scripts/analytics/ics_acquisition/09_ics_vs_portfolio.py
@@ -61,8 +61,8 @@ else:
 
         fig.suptitle("ICS vs Full Portfolio",
                      fontsize=26, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], y=1.04)
-        fig.text(0.5, 0.96,
+                     color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+        fig.text(0.5, GEN_SUBTITLE_Y,
                  f"How do ICS top merchants compare to the overall member base?  ({DATASET_LABEL})",
                  ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 

--- a/01_Analysis/00-Scripts/analytics/mcc_code/02_mcc_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/mcc_code/02_mcc_kpi.py
@@ -43,7 +43,7 @@ else:
 
     fig.suptitle("Merchant Category Concentration",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
     plt.tight_layout()
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/mcc_code/11_mcc_by_biz_personal.py
+++ b/01_Analysis/00-Scripts/analytics/mcc_code/11_mcc_by_biz_personal.py
@@ -70,8 +70,8 @@ else:
 
         fig.suptitle("Top MCC Categories: Business vs Personal",
                      fontsize=26, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], y=1.04)
-        fig.text(0.5, 0.96, "Do business and personal accounts use different merchant categories?",
+                     color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+        fig.text(0.5, GEN_SUBTITLE_Y, "Do business and personal accounts use different merchant categories?",
                  ha='center', fontsize=15, color=GEN_COLORS['muted'], style='italic')
 
         plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/mcc_code/13_mcc_diversity.py
+++ b/01_Analysis/00-Scripts/analytics/mcc_code/13_mcc_diversity.py
@@ -90,8 +90,8 @@ else:
 
     fig.suptitle("MCC Category Breadth per Account",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "Do active accounts use more merchant categories?",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "Do active accounts use more merchant categories?",
              ha='center', fontsize=15, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/merchant/02_merchant_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/merchant/02_merchant_kpi.py
@@ -57,7 +57,7 @@ for ax, kpi in zip(axes, kpi_data):
 
 fig.suptitle("Merchant Portfolio Overview",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/merchant/04_merchant_donut.py
+++ b/01_Analysis/00-Scripts/analytics/merchant/04_merchant_donut.py
@@ -77,7 +77,7 @@ ax2.text(9.5, y_header, 'Share', fontsize=10, color=GEN_COLORS['muted'],
 
 fig.suptitle("Top Merchant Breakdown",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/merchant/08_merchant_volatility.py
+++ b/01_Analysis/00-Scripts/analytics/merchant/08_merchant_volatility.py
@@ -14,7 +14,14 @@ if len(consistency_df) > 0:
     ax1.barh(range(len(con_plot)), con_plot['cv'],
              color=GEN_COLORS['info'], edgecolor='white', linewidth=0.5, height=0.6)
     ax1.set_yticks(range(len(con_plot)))
-    ax1.set_yticklabels(con_plot['merchant_consolidated'].str[:25], fontsize=11, fontweight='bold')
+    # astype(str) guards against categorical dtype (txn_wrapper optimizes
+    # merchant_consolidated to category for memory), NaN values, and the
+    # long-string edge case that blew up with a bogus figsize width in
+    # matplotlib's text metrics. Same defensive cast used in payroll/05.
+    ax1.set_yticklabels(
+        con_plot['merchant_consolidated'].astype(str).str[:25],
+        fontsize=11, fontweight='bold',
+    )
     ax1.set_xlabel("CV %  (lower = more stable)", fontsize=13, fontweight='bold', labelpad=8)
     gen_clean_axes(ax1, keep_left=True, keep_bottom=True)
     ax1.xaxis.grid(True, color=GEN_COLORS['grid'], linewidth=0.5, alpha=0.7)
@@ -34,7 +41,10 @@ if len(consistency_df) > 0:
     ax2.barh(range(len(vol_plot)), vol_plot['cv_display'],
              color=GEN_COLORS['warning'], edgecolor='white', linewidth=0.5, height=0.6)
     ax2.set_yticks(range(len(vol_plot)))
-    ax2.set_yticklabels(vol_plot['merchant_consolidated'].str[:25], fontsize=11, fontweight='bold')
+    ax2.set_yticklabels(
+        vol_plot['merchant_consolidated'].astype(str).str[:25],
+        fontsize=11, fontweight='bold',
+    )
     ax2.set_xlabel("CV %  (higher = more volatile)", fontsize=13, fontweight='bold', labelpad=8)
     ax2.set_xlim(0, 350)
     gen_clean_axes(ax2, keep_left=True, keep_bottom=True)
@@ -49,14 +59,23 @@ if len(consistency_df) > 0:
         ax2.text(x_pos, j, label,
                  va='center', fontsize=10, fontweight='bold', color=GEN_COLORS['warning'])
 
+    # Place suptitle INSIDE the figure (y=0.99) rather than above the frame
+    # (y=1.04). Combined with tight_layout() + subplots_adjust(top=0.88),
+    # the old above-frame placement created a negative inner height that
+    # matplotlib's text-metric pipeline occasionally translated into a
+    # wildly overflowed width (the ``width=16345162437324666'' crash we
+    # saw in merchant_08 during a 1776 run). Keeping all layout directives
+    # within the [0, 1] figure coord space prevents the overflow.
     fig.suptitle("Merchant Spend Consistency",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "Coefficient of variation: stable vs spiky merchants ($10K+ spend, 3+ months, CV capped at 500%)",
+                 color=GEN_COLORS['dark_text'], y=0.99)
+    fig.text(0.5, 0.93, "Coefficient of variation: stable vs spiky merchants ($10K+ spend, 3+ months, CV capped at 500%)",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
-    plt.tight_layout()
-    plt.subplots_adjust(top=0.88)
+    # Reserve headroom for the title via subplots_adjust ONLY -- don't
+    # also call tight_layout, which can undo the reservation and produce
+    # the conflicting-layout crash above.
+    plt.subplots_adjust(top=0.86, bottom=0.08, left=0.15, right=0.97, wspace=0.45)
     plt.show()
 
     # Summary

--- a/01_Analysis/00-Scripts/analytics/merchant/10_merchant_by_biz_personal.py
+++ b/01_Analysis/00-Scripts/analytics/merchant/10_merchant_by_biz_personal.py
@@ -56,8 +56,8 @@ if 'business_flag' in combined_df.columns:
 
     fig.suptitle("Top Merchants: Business vs Personal",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "Do business and personal accounts rely on different merchants?",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "Do business and personal accounts rely on different merchants?",
              ha='center', fontsize=15, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/payroll/02_payroll_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/payroll/02_payroll_kpi.py
@@ -88,7 +88,7 @@ for ax, kpi in zip(axes, kpi_data):
 
 fig.suptitle("Payroll & Direct Deposit Detection",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=1.06)
+             color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=GEN_TITLE_Y)
 fig.text(0.01, 1.00,
          f"Primary Financial Institution signal  --  {DATASET_LABEL}",
          fontsize=14, style='italic', color=GEN_COLORS['muted'],

--- a/01_Analysis/00-Scripts/analytics/payroll/05_payroll_by_demographics.py
+++ b/01_Analysis/00-Scripts/analytics/payroll/05_payroll_by_demographics.py
@@ -155,7 +155,7 @@ gen_clean_axes(ax3)
 # ---------------------------------------------------------------------------
 fig.suptitle("Payroll Penetration by Demographics",
              fontsize=26, fontweight='bold',
-             color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=1.06)
+             color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=GEN_TITLE_Y)
 fig.text(0.01, 1.01,
          f"Where is payroll detection strongest and weakest?  --  {DATASET_LABEL}",
          fontsize=13, style='italic', color=GEN_COLORS['muted'],

--- a/01_Analysis/00-Scripts/analytics/payroll/05_payroll_by_demographics.py
+++ b/01_Analysis/00-Scripts/analytics/payroll/05_payroll_by_demographics.py
@@ -130,7 +130,14 @@ if 'branch' in payroll_df.columns and payroll_df['branch'].notna().sum() > 0:
                  fontsize=11, fontweight='bold', color=GEN_COLORS['dark_text'])
 
     ax3.set_yticks(range(len(branch_penet)))
-    ax3.set_yticklabels(branch_penet['branch'].str[:20], fontsize=11, fontweight='bold')
+    # Cast branch to string before slicing: when branch_config.json is
+    # missing, branch column contains numeric IDs and .str[] blows up with
+    # ``Can only use .str accessor with string values!''. astype(str) is
+    # safe for both numeric and string branch columns.
+    ax3.set_yticklabels(
+        branch_penet['branch'].astype(str).str[:20],
+        fontsize=11, fontweight='bold',
+    )
     ax3.set_title("By Branch (Top 15)", fontsize=18, fontweight='bold',
                   color=GEN_COLORS['dark_text'], loc='left')
 else:

--- a/01_Analysis/00-Scripts/analytics/payroll/07_payroll_retention.py
+++ b/01_Analysis/00-Scripts/analytics/payroll/07_payroll_retention.py
@@ -90,7 +90,7 @@ if has_attrition:
 
     fig.suptitle("Payroll Status vs Attrition Risk",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=1.04)
+                 color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=GEN_TITLE_Y)
     fig.text(0.01, 0.99,
              f"Payroll as a retention anchor  --  {DATASET_LABEL}",
              fontsize=13, style='italic', color=GEN_COLORS['muted'],
@@ -223,7 +223,7 @@ else:
     period_label = f"{first_months[0]} to {last_months[-1]}" if first_months and last_months else ""
     fig.suptitle("Payroll as a Retention Anchor: Spend Velocity Analysis",
                  fontsize=24, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=1.06)
+                 color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=GEN_TITLE_Y)
     fig.text(0.01, 1.01,
              f"Activity change {period_label}  --  {DATASET_LABEL}",
              fontsize=13, style='italic', color=GEN_COLORS['muted'],

--- a/01_Analysis/00-Scripts/analytics/payroll/08_pfi_composite_score.py
+++ b/01_Analysis/00-Scripts/analytics/payroll/08_pfi_composite_score.py
@@ -208,7 +208,7 @@ ax2.set_title("Score Distribution (0-20)", fontsize=20, fontweight='bold',
 
 fig.suptitle("PFI Composite Score: Member Relationship Depth",
              fontsize=26, fontweight='bold',
-             color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=1.06)
+             color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=GEN_TITLE_Y)
 fig.text(0.01, 1.01,
          f"Payroll (5) + Balance (4) + Activity (4) + Products (3) + Tenure (3) + Bill Pay (1)  --  {DATASET_LABEL}",
          fontsize=12, style='italic', color=GEN_COLORS['muted'],

--- a/01_Analysis/00-Scripts/analytics/payroll/09_pfi_vs_competitor.py
+++ b/01_Analysis/00-Scripts/analytics/payroll/09_pfi_vs_competitor.py
@@ -99,7 +99,7 @@ if has_competitor:
 
         fig.suptitle("PFI Tier vs Competitor Leakage",
                      fontsize=26, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=1.06)
+                     color=GEN_COLORS['dark_text'], x=0.01, ha='left', y=GEN_TITLE_Y)
         fig.text(0.01, 1.01,
                  f"Weaker PFI relationships correlate with more competitor activity  --  {DATASET_LABEL}",
                  fontsize=13, style='italic', color=GEN_COLORS['muted'],

--- a/01_Analysis/00-Scripts/analytics/payroll/10_action_summary.py
+++ b/01_Analysis/00-Scripts/analytics/payroll/10_action_summary.py
@@ -80,7 +80,12 @@ if 'branch' in payroll_df.columns and payroll_df['branch'].notna().sum() > 0:
 
     if len(branch_penet) > 0:
         lowest_branches = branch_penet.nsmallest(3, 'pct')
-        branch_names = ', '.join(lowest_branches['branch'].str[:15].tolist())
+        # astype(str) first: when branch_config.json is missing, branch
+        # column is numeric and .str[] raises ``Can only use .str accessor
+        # with string values!''. Harmless when branch is already string.
+        branch_names = ', '.join(
+            lowest_branches['branch'].astype(str).str[:15].tolist()
+        )
         avg_low = lowest_branches['pct'].mean()
         findings.append({
             'Category': 'Branch Gaps',
@@ -185,7 +190,7 @@ if 'branch' in payroll_df.columns and payroll_df['branch'].notna().sum() > 0:
     if len(branch_penet) > 0:
         lowest_br = branch_penet.nsmallest(3, 'pct')
         actions.append({
-            'Action': f"Branch-specific payroll drives at {', '.join(lowest_br['branch'].str[:12].tolist())}",
+            'Action': f"Branch-specific payroll drives at {', '.join(lowest_br['branch'].astype(str).str[:12].tolist())}",
             'Target': f"~{lowest_br['total'].sum():,} accounts at low-penetration branches",
             'Expected Impact': f"Close {abs(pct_payroll - lowest_br['pct'].mean()):.0f}pp gap vs CU average",
             'Priority': 'Medium',

--- a/01_Analysis/00-Scripts/analytics/personal_accts/02_personal_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/personal_accts/02_personal_kpi.py
@@ -57,7 +57,7 @@ for ax, kpi in zip(axes, kpi_data):
 
 fig.suptitle("Personal Account Portfolio Overview",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/personal_accts/04_personal_donut.py
+++ b/01_Analysis/00-Scripts/analytics/personal_accts/04_personal_donut.py
@@ -76,7 +76,7 @@ ax2.text(9.5, y_header, 'Share', fontsize=10, color=GEN_COLORS['muted'],
 
 fig.suptitle("Personal Account Merchant Breakdown",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/personal_accts/08_personal_volatility.py
+++ b/01_Analysis/00-Scripts/analytics/personal_accts/08_personal_volatility.py
@@ -51,8 +51,8 @@ if len(pers_consistency_df) > 0:
 
     fig.suptitle("Personal Merchant Spend Consistency",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "Stable vs spiky personal merchants ($10K+ spend, 3+ months, CV capped at 500%)",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "Stable vs spiky personal merchants ($10K+ spend, 3+ months, CV capped at 500%)",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/personal_accts/10_personal_vs_portfolio.py
+++ b/01_Analysis/00-Scripts/analytics/personal_accts/10_personal_vs_portfolio.py
@@ -52,8 +52,8 @@ try:
 
     fig.suptitle("Personal vs Full Portfolio",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "How do personal account top merchants compare to the overall member base?",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "How do personal account top merchants compare to the overall member base?",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/product/02_product_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/product/02_product_kpi.py
@@ -64,7 +64,7 @@ else:
 
     fig.suptitle("Card Product Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
     plt.tight_layout()
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/product/04_product_donut.py
+++ b/01_Analysis/00-Scripts/analytics/product/04_product_donut.py
@@ -60,8 +60,8 @@ else:
 
     fig.suptitle("Card Product Mix",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "How is transaction volume distributed across card products?",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "How is transaction volume distributed across card products?",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/product/05_product_spend_profile.py
+++ b/01_Analysis/00-Scripts/analytics/product/05_product_spend_profile.py
@@ -49,8 +49,8 @@ else:
 
     fig.suptitle("Product Spend & Activity Profile",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.96, "Which products generate the highest-value and most frequent usage?",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, "Which products generate the highest-value and most frequent usage?",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/rege_overdraft/02_rege_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/rege_overdraft/02_rege_kpi.py
@@ -57,7 +57,7 @@ for ax, (value, label, color) in zip(axes, kpis):
 
 fig.suptitle("Reg E Opt-In Health at a Glance",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 fig.text(0.5, 0.98,
          f"Overdraft coverage enrollment across all accounts | {DATASET_LABEL}",
          fontsize=14, color=GEN_COLORS['muted'], style='italic',

--- a/01_Analysis/00-Scripts/analytics/rege_overdraft/05_od_limit_distribution.py
+++ b/01_Analysis/00-Scripts/analytics/rege_overdraft/05_od_limit_distribution.py
@@ -104,7 +104,7 @@ ax2.set_title("Accounts by OD Limit Band", fontsize=18,
 
 fig.suptitle("Overdraft Limit Distribution",
              fontsize=26, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 fig.text(0.5, 0.99,
          f"Current OD limit amounts across all accounts | {DATASET_LABEL}",
          fontsize=14, color=GEN_COLORS['muted'], style='italic',

--- a/01_Analysis/00-Scripts/analytics/rege_overdraft/07_rege_by_demographics.py
+++ b/01_Analysis/00-Scripts/analytics/rege_overdraft/07_rege_by_demographics.py
@@ -112,7 +112,7 @@ else:
 
     fig.suptitle("Reg E Opt-In Rate by Demographics",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
     fig.text(0.5, 0.99,
              f"Which segments are opting out most? | {DATASET_LABEL}",
              fontsize=14, color=GEN_COLORS['muted'], style='italic',

--- a/01_Analysis/00-Scripts/analytics/rege_overdraft/08_rege_revenue_exposure.py
+++ b/01_Analysis/00-Scripts/analytics/rege_overdraft/08_rege_revenue_exposure.py
@@ -128,7 +128,7 @@ ax2.set_title("Revenue Sensitivity", fontsize=18,
 
 fig.suptitle("Reg E Revenue Exposure Analysis",
              fontsize=26, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 fig.text(0.5, 0.99,
          f"OD fee revenue potential and erosion scenarios | {DATASET_LABEL}",
          fontsize=14, color=GEN_COLORS['muted'], style='italic',

--- a/01_Analysis/00-Scripts/analytics/rege_overdraft/09_rege_vs_balance.py
+++ b/01_Analysis/00-Scripts/analytics/rege_overdraft/09_rege_vs_balance.py
@@ -140,7 +140,7 @@ if _bal_col and _bal_col in rege_df.columns:
 
     fig.suptitle("Reg E Opt-In vs Account Balance",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
     fig.text(0.5, 0.99,
              f"Where does opt-in status matter most? | {DATASET_LABEL}",
              fontsize=14, color=GEN_COLORS['muted'], style='italic',

--- a/01_Analysis/00-Scripts/analytics/relationship/02_relationship_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/relationship/02_relationship_kpi.py
@@ -94,8 +94,8 @@ else:
 
     fig.suptitle("Member Relationship Depth",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.01, 0.97,
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.01, GEN_SUBTITLE_Y,
              f"Single-product members are 3x more likely to leave  |  {DATASET_LABEL}",
              fontsize=14, color=GEN_COLORS['muted'], style='italic')
 

--- a/01_Analysis/00-Scripts/analytics/relationship/06_relationship_value.py
+++ b/01_Analysis/00-Scripts/analytics/relationship/06_relationship_value.py
@@ -141,7 +141,7 @@ else:
 
     fig.suptitle("The Staircase Effect: More Products = More Value",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.06)
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
     fig.text(0.01, 1.01,
              f"Each additional product adds significant member value  |  "
              f"Top-tier members worth {multiplier:.1f}x single-product  |  {DATASET_LABEL}",

--- a/01_Analysis/00-Scripts/analytics/relationship/08_relationship_by_demographics.py
+++ b/01_Analysis/00-Scripts/analytics/relationship/08_relationship_by_demographics.py
@@ -164,7 +164,7 @@ else:
 
         fig.suptitle("Relationship Depth by Demographic Segment",
                      fontsize=26, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], y=1.06)
+                     color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
         fig.text(0.01, 1.01,
                  f"Which segments have the shallowest relationships?  |  {DATASET_LABEL}",
                  transform=fig.transFigure, fontsize=14,

--- a/01_Analysis/00-Scripts/analytics/retention/02_retention_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/retention/02_retention_kpi.py
@@ -77,8 +77,8 @@ else:
 
     fig.suptitle("Retention & Churn Overview",
                  fontsize=28, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.04)
-    fig.text(0.5, 0.97, f"Account health classification  |  {DATASET_LABEL}",
+                 color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+    fig.text(0.5, GEN_SUBTITLE_Y, f"Account health classification  |  {DATASET_LABEL}",
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/segment_evolution/02_segment_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/segment_evolution/02_segment_kpi.py
@@ -88,8 +88,8 @@ else:
 
         fig.suptitle("Segment Migration Overview",
                      fontsize=28, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], y=1.04)
-        fig.text(0.5, 0.97,
+                     color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+        fig.text(0.5, GEN_SUBTITLE_Y,
                  f"First vs. last segmentation wave  ({DATASET_LABEL})",
                  ha='center', fontsize=13,
                  color=GEN_COLORS['muted'], style='italic')

--- a/01_Analysis/00-Scripts/analytics/transaction_type/02_txn_type_kpi.py
+++ b/01_Analysis/00-Scripts/analytics/transaction_type/02_txn_type_kpi.py
@@ -57,7 +57,7 @@ for ax, kpi in zip(axes, kpi_data):
 
 fig.suptitle("Transaction Type Overview",
              fontsize=28, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
 
 plt.tight_layout()
 plt.show()

--- a/01_Analysis/00-Scripts/analytics/transaction_type/03_txn_type_split.py
+++ b/01_Analysis/00-Scripts/analytics/transaction_type/03_txn_type_split.py
@@ -74,8 +74,8 @@ ax2.set_title("By Spend Volume", fontsize=18, fontweight='bold',
 
 fig.suptitle("Transaction Type Distribution",
              fontsize=26, fontweight='bold',
-             color=GEN_COLORS['dark_text'], y=1.04)
-fig.text(0.5, 0.96, "How does card volume split between PIN and signature?",
+             color=GEN_COLORS['dark_text'], y=GEN_TITLE_Y)
+fig.text(0.5, GEN_SUBTITLE_Y, "How does card volume split between PIN and signature?",
          ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
 plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/txn_setup/02-file-config.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/02-file-config.py
@@ -180,17 +180,44 @@ older_files = [f for f, d in dated_files if d < window_start]
 # 5) Include unparsed files (can't determine date -- safer to include)
 files_to_load = recent_files + unparsed_files
 
-# 6) Check Parquet cache -- if it's newer than ALL TXN files, skip file reading
-if PARQUET_CACHE.exists() and files_to_load:
+# 6) Check Parquet cache -- if it's newer than ALL TXN files, skip file reading.
+# The single most impactful speedup: the first run spends ~26 minutes reading
+# 14+ TXN files off the M: network share; subsequent runs load the cached
+# .parquet in seconds. Every branch of this decision prints a status line so
+# users can tell at a glance why a given run is slow.
+print()
+print("-" * 60)
+print("PARQUET CACHE STATUS")
+print("-" * 60)
+if not PARQUET_CACHE.exists():
+    print(f"  Status: NO CACHE (will be built during this run)")
+    print(f"  Location: {PARQUET_CACHE}")
+    print(f"  Note: first run for this client is slow; subsequent runs are fast.")
+elif not files_to_load:
+    # Cache exists but no raw files -- rely on cache
+    USE_PARQUET_CACHE = PARQUET_CACHE
+    _cache_mtime = PARQUET_CACHE.stat().st_mtime
+    print(f"  Status: HIT (no raw TXN files found; using cache)")
+    print(f"  Cache:  {PARQUET_CACHE.name}")
+    print(f"  Date:   {datetime.fromtimestamp(_cache_mtime):%Y-%m-%d %H:%M}")
+else:
     _cache_mtime = PARQUET_CACHE.stat().st_mtime
     _newest_file_mtime = max(f.stat().st_mtime for f in files_to_load)
     if _cache_mtime > _newest_file_mtime:
         USE_PARQUET_CACHE = PARQUET_CACHE
-        print(f"CACHE HIT: Loading from Parquet cache (faster)")
-        print(f"  Cache: {PARQUET_CACHE.name}")
-        print(f"  Cache date: {datetime.fromtimestamp(_cache_mtime):%Y-%m-%d %H:%M}")
+        _age_hours = (datetime.now().timestamp() - _cache_mtime) / 3600
+        _cache_mb = PARQUET_CACHE.stat().st_size / (1024 * 1024)
+        print(f"  Status: HIT (skipping file read, saving ~25 min)")
+        print(f"  Cache:  {PARQUET_CACHE.name} ({_cache_mb:.0f} MB)")
+        print(f"  Date:   {datetime.fromtimestamp(_cache_mtime):%Y-%m-%d %H:%M} ({_age_hours:.1f}h old)")
     else:
-        print(f"CACHE MISS: New TXN files detected, rebuilding from source")
+        _newest_file_dt = datetime.fromtimestamp(_newest_file_mtime)
+        _cache_dt = datetime.fromtimestamp(_cache_mtime)
+        print(f"  Status: MISS (newer TXN files present -- rebuilding)")
+        print(f"  Cache date:   {_cache_dt:%Y-%m-%d %H:%M}")
+        print(f"  Newest file:  {_newest_file_dt:%Y-%m-%d %H:%M}")
+print("-" * 60)
+print()
 
 # TXN files are read directly from the network share.
 # The Parquet cache (above) is the real speed optimization -- after the first

--- a/01_Analysis/00-Scripts/analytics/txn_setup/04-define-data-func.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/04-define-data-func.py
@@ -32,31 +32,91 @@ DTYPE_HINTS = {
 }
 
 
+def _sniff_delimiter(filepath, sample_bytes=8192):
+    """Detect delimiter from FILE CONTENT, not just extension.
+
+    Reads the first few KB and counts tabs vs commas. The winner is the
+    real delimiter. Falls back to extension-based guessing only if the
+    sample is empty or both counts tie at zero.
+
+    Why content-based: some clients deliver TSV data with a .csv
+    extension (e.g. 1441 / FNB Alaska, 4/26 run, issue #95). Pandas read
+    that file with sep=',' because of the extension; the header line had
+    no commas so it was parsed as 1 column; line 278 happened to contain
+    a literal comma inside a field, suddenly making it look like 2
+    columns and crashing the entire pipeline with the unhelpful
+    ``Expected 1 fields, saw 2''. Sniffing the actual delimiter prevents
+    this whole class of failure.
+    """
+    try:
+        with open(filepath, 'rb') as fh:
+            sample = fh.read(sample_bytes).decode('utf-8', errors='replace')
+        # Count delimiter occurrences only on lines after the first to
+        # avoid an unusually delimiter-heavy header skewing the count.
+        lines = sample.splitlines()[1:5] if len(sample.splitlines()) > 1 else sample.splitlines()
+        joined = '\n'.join(lines) if lines else sample
+        n_tabs = joined.count('\t')
+        n_commas = joined.count(',')
+        if n_tabs == 0 and n_commas == 0:
+            # Couldn't sniff -- fall back to extension
+            return ',' if filepath.suffix.lower() == '.csv' else '\t'
+        return '\t' if n_tabs > n_commas else ','
+    except Exception:
+        # If we can't even read it, defer the explosion to pd.read_csv
+        # which will give a clearer error
+        return ',' if filepath.suffix.lower() == '.csv' else '\t'
+
+
 def load_transaction_file(filepath):
     """Load a debit card transaction file (.txt or .csv).
 
-    Detects delimiter automatically: tab for .txt, comma for .csv.
-    Some clients use .csv with commas, others use .txt with tabs.
-    The format never changes within one client across months.
+    Delimiter is detected from file CONTENT (not just extension).
+    Mismatched extension+content (e.g. .csv that's actually tab-delimited)
+    used to crash with ``Error tokenizing data. Expected 1 fields,
+    saw 2'' -- now handled transparently with a content-aware sniff
+    plus retry-with-other-delimiter fallback in both directions.
     """
     filepath = Path(filepath)
 
-    # Detect delimiter by file extension
-    if filepath.suffix.lower() == '.csv':
-        sep = ','
-    else:
-        sep = '\t'
+    # Pick delimiter from content, not extension
+    sep = _sniff_delimiter(filepath)
+    sep_label = 'TAB' if sep == '\t' else 'COMMA'
+    extension_guess = ',' if filepath.suffix.lower() == '.csv' else '\t'
+    if sep != extension_guess:
+        ext_label = 'TAB' if extension_guess == '\t' else 'COMMA'
+        print(f"  NOTE: {filepath.name} extension suggests {ext_label} but content is {sep_label}; using {sep_label}")
 
     # Use dtype hints to skip type inference (big speedup on millions of rows)
-    df = pd.read_csv(filepath, sep=sep, skiprows=1, header=None,
-                     dtype=DTYPE_HINTS, low_memory=False, na_values=['', 'NA', 'N/A'])
-
-    # Warn if column count is unexpected
-    if len(df.columns) == 1 and sep == '\t':
-        # Might be a comma-separated file with .txt extension -- retry
-        print(f"  WARNING: {filepath.name} has 1 column with tab delimiter, retrying with comma...")
-        df = pd.read_csv(filepath, sep=',', skiprows=1, header=None,
+    try:
+        df = pd.read_csv(filepath, sep=sep, skiprows=1, header=None,
                          dtype=DTYPE_HINTS, low_memory=False, na_values=['', 'NA', 'N/A'])
+    except Exception as exc:
+        print(f"  WARNING: {filepath.name} failed parse with {sep_label}: {type(exc).__name__}: {exc}")
+        # Try the other delimiter as a last resort
+        other = ',' if sep == '\t' else '\t'
+        other_label = 'TAB' if other == '\t' else 'COMMA'
+        print(f"           Retrying with {other_label}...")
+        df = pd.read_csv(filepath, sep=other, skiprows=1, header=None,
+                         dtype=DTYPE_HINTS, low_memory=False, na_values=['', 'NA', 'N/A'])
+        sep = other
+        sep_label = other_label
+
+    # Both-direction retry: if we ended up with 1 column, the sniff was
+    # probably wrong (e.g. file with no delimiters in the first 4 lines
+    # because every field was empty). Try the OTHER delimiter.
+    if len(df.columns) == 1:
+        other = ',' if sep == '\t' else '\t'
+        other_label = 'TAB' if other == '\t' else 'COMMA'
+        print(f"  WARNING: {filepath.name} parsed to 1 column with {sep_label}; retrying with {other_label}")
+        try:
+            df_retry = pd.read_csv(filepath, sep=other, skiprows=1, header=None,
+                                   dtype=DTYPE_HINTS, low_memory=False, na_values=['', 'NA', 'N/A'])
+            if len(df_retry.columns) > 1:
+                df = df_retry
+                sep = other
+                sep_label = other_label
+        except Exception as exc:
+            print(f"           Retry also failed: {type(exc).__name__}: {exc}")
 
     if len(df.columns) != len(EXPECTED_COLUMNS):
         print(f"  WARNING: {filepath.name} has {len(df.columns)} columns (expected {len(EXPECTED_COLUMNS)})")

--- a/01_Analysis/00-Scripts/analytics/txn_setup/04-define-data-func.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/04-define-data-func.py
@@ -121,6 +121,50 @@ def load_transaction_file(filepath):
     if len(df.columns) != len(EXPECTED_COLUMNS):
         print(f"  WARNING: {filepath.name} has {len(df.columns)} columns (expected {len(EXPECTED_COLUMNS)})")
 
+    # ----------------------------------------------------------
+    # Drop header rows that survived skiprows=1
+    # ----------------------------------------------------------
+    # Some clients (e.g. FNB Alaska / 1441) deliver TXN files with a
+    # metadata banner BEFORE the actual header line:
+    #
+    #   "Report: Debit Card Transactions; Generated 2026-04-26"   <- banner
+    #   "Transaction Date<TAB>Account<TAB>Type<TAB>Amount..."     <- header
+    #   "2026-04-01<TAB>12345<TAB>PIN<TAB>5.00..."                <- data
+    #
+    # skiprows=1 strips the banner; the header row survives as ``row 0''
+    # and breaks every downstream type coercion (date parse fails on the
+    # literal string "Transaction Date", amount becomes NaN, etc.).
+    #
+    # Detect-and-drop: if the first 1-2 rows contain values matching known
+    # header keywords (case-insensitive substring), drop them. Safe for
+    # files that do NOT have a banner -- they parsed cleanly to begin with
+    # and these rows simply don't match.
+    _header_keywords = (
+        'transaction date', 'transaction_date', 'trans date', 'date',
+        'account number', 'account_number', 'primary account', 'acct',
+        'transaction type', 'trans type', 'type code',
+        'amount', 'mcc', 'merchant', 'terminal', 'institution',
+    )
+    _max_rows_to_check = 2
+    _dropped_header_rows = 0
+    for _ in range(_max_rows_to_check):
+        if len(df) == 0:
+            break
+        # Build a single concatenated lowercase string of the first row's
+        # non-null values, then check if any header-keyword appears in it.
+        try:
+            _first_row = df.iloc[0].astype(str).str.lower()
+            _joined = ' '.join(v for v in _first_row.values if v and v != 'nan')
+        except Exception:
+            break
+        _looks_like_header = any(kw in _joined for kw in _header_keywords)
+        if not _looks_like_header:
+            break
+        df = df.iloc[1:].reset_index(drop=True)
+        _dropped_header_rows += 1
+    if _dropped_header_rows:
+        print(f"  Dropped {_dropped_header_rows} surviving header row(s) from {filepath.name}")
+
     # Assign column names
     df.columns = EXPECTED_COLUMNS[:len(df.columns)]
 

--- a/01_Analysis/00-Scripts/analytics/txn_setup/06-merchant-name-consolidation.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/06-merchant-name-consolidation.py
@@ -5,6 +5,67 @@ Works across all clients to consolidate common merchant name variations.
 Add this to your notebook and use it in your merchant analysis sections.
 """
 
+import re as _re_clean
+
+# Carrier prefixes that banks/processors prepend to the REAL merchant string.
+# Stripped BEFORE brand matching so "ACH CREDIT SESLOC CREDIT UNION 805-555"
+# becomes "SESLOC CREDIT UNION 805-555" and prefix-match in tag_competitors
+# correctly tags it as a credit_union.
+#
+# This is the root cause of the 1776 undercount: wallets/BNPL brands
+# (VENMO, ZELLE, PAYPAL, AFFIRM, KLARNA, AFTERPAY) have EXPLICIT rules in
+# this file that reduce them to clean names, so tag_competitors' prefix
+# match works. Credit unions and local banks have NO explicit rules -- so
+# "ACH CREDIT SESLOC CREDIT UNION" stays messy and prefix-match FAILS,
+# dropping the transaction entirely from competitor_txns.
+_CARRIER_PREFIX_RE = _re_clean.compile(
+    r'^(?:'
+    r'DEBIT\s+PURCHASE|DEBIT\s+CARD\s+PURCHASE|DEBIT\s+POS|DEBIT|'
+    r'CREDIT\s+PURCHASE|CREDIT\s+CARD|CREDIT|'
+    r'POS\s+PURCHASE|POS\s+DEBIT|POS|'
+    r'ACH\s+DEBIT|ACH\s+CREDIT|ACH\s+PAYMENT|ACH\s+WEB|ACH|'
+    r'PURCHASE\s+AUTHORIZED|PURCHASE|'
+    r'PAYMENT\s+TO|PAYMENT|'
+    r'EXTERNAL\s+TRANSFER|EXT\s+TRANSFER|EXT\s+XFER|EXT|'
+    r'ONLINE\s+TRANSFER|WEB\s+TRANSFER|TRANSFER|XFER|'
+    r'DIRECT\s+DEP|DIRECT\s+DEBIT|'
+    r'RECURRING\s+PAYMENT|RECURRING|'
+    r'CKCD|DEB|CRD'
+    r')\s+',
+    _re_clean.IGNORECASE,
+)
+
+# Trailing per-transaction noise that prevents clean grouping later:
+# phone numbers, account digits, two-letter state codes.
+_TRAILING_STATE_RE  = _re_clean.compile(r'\s+[A-Z]{2}$')
+_TRAILING_DIGITS_RE = _re_clean.compile(r'\s+[\d\-]{3,}$')
+_TRAILING_PHONE_RE  = _re_clean.compile(r'\s+(?:\d{3}[-\s]?\d{3}[-\s]?\d{4})$')
+
+
+def _strip_carrier_noise(merchant_upper):
+    """Remove carrier prefix + per-txn tail so the real merchant name is at
+    position 0. Safe for every merchant type including wallets/BNPL (their
+    rules below still work because brand rules use `in merchant_upper`
+    substring checks, not prefix checks)."""
+    # Strip leading carrier prefix up to 3 times to handle doubled prefixes
+    # like "POS DEBIT PURCHASE"
+    for _ in range(3):
+        new = _CARRIER_PREFIX_RE.sub('', merchant_upper, count=1)
+        if new == merchant_upper:
+            break
+        merchant_upper = new
+    # Strip trailing noise in a loop until stable so
+    # "RANDOM SHOP 123456 CA" collapses to "RANDOM SHOP" in one call.
+    for _ in range(4):
+        prev = merchant_upper
+        merchant_upper = _TRAILING_PHONE_RE.sub('', merchant_upper)
+        merchant_upper = _TRAILING_DIGITS_RE.sub('', merchant_upper)
+        merchant_upper = _TRAILING_STATE_RE.sub('', merchant_upper)
+        if merchant_upper == prev:
+            break
+    return merchant_upper.strip()
+
+
 def standardize_merchant_name(merchant_name):
     """
     Consolidate duplicate merchant variations across all clients.
@@ -16,10 +77,18 @@ def standardize_merchant_name(merchant_name):
 
     # Normalize: strip whitespace, convert to uppercase
     merchant_upper = str(merchant_name).strip().upper()
-    
+
     # Remove extra spaces (multiple spaces → single space)
     merchant_upper = ' '.join(merchant_upper.split())
-    
+
+    # Strip carrier prefix ("DEBIT POS", "ACH CREDIT", etc.) + per-txn
+    # tail (phone, digits, state) so brand rules below and downstream
+    # prefix-match in tag_competitors see the REAL merchant name. Wallet
+    # and BNPL rules below use substring checks so this does not change
+    # their behavior; CUs / local banks / misc competitors gain correct
+    # tagging that was silently missing.
+    merchant_upper = _strip_carrier_noise(merchant_upper)
+
     # ============================================================================
     # TECH & DIGITAL SERVICES
     # ============================================================================
@@ -796,6 +865,10 @@ def standardize_merchant_name(merchant_name):
         return 'HONDA FINANCE'
         
     # ============================================================================
-    # If no match, return original
+    # If no explicit brand rule fired, return the NOISE-STRIPPED + UPPERCASED
+    # version instead of the raw input. This is what lets CUs, local banks,
+    # and other competitors get tagged correctly downstream: tag_competitors
+    # prefix-matches on this value, so "SESLOC CREDIT UNION" (clean) works
+    # but "ACH CREDIT SESLOC CREDIT UNION 805-555" (raw) does not.
     # ============================================================================
-    return merchant_name
+    return merchant_upper if merchant_upper else merchant_name

--- a/01_Analysis/00-Scripts/analytics/txn_setup/06-merchant-name-consolidation.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/06-merchant-name-consolidation.py
@@ -738,9 +738,47 @@ def standardize_merchant_name(merchant_name):
     if 'UPSTART' in merchant_upper:
         return 'UPSTART'
     
-    if 'ROCKET' in merchant_upper and ('MORTGAGE' in merchant_upper or 'LOANS' in merchant_upper):
+    if 'ROCKET' in merchant_upper:
+        # Catches: ``ROCKET MORTGAGE'', ``ROCKET LOANS'', ``ROCKET SAVINGS DEPOSIT'',
+        # ``ROCKET MTG''. Previously the AND clause missed ``ROCKET SAVINGS DEPOSIT''
+        # (saw 2,314 of these untagged in 1441).
+        if 'SAVINGS' in merchant_upper:
+            return 'ROCKET MONEY'
         return 'ROCKET MORTGAGE'
-    
+
+    if 'LENDINGCLUB' in merchant_upper or 'LENDING CLUB' in merchant_upper:
+        return 'LENDING CLUB'
+
+    # ============================================================================
+    # CREDIT CARDS / SUBPRIME (additional rules added based on 1441 diagnostic)
+    # ============================================================================
+
+    # Apple Card -- shows up as ``APPLECARD GSBANK PAYMENT'' on 1441 (11,521 txns).
+    # GS Bank = Goldman Sachs Bank, Apple's card issuer. Collapse all variants.
+    if 'APPLECARD' in merchant_upper or 'APPLE CARD' in merchant_upper:
+        return 'APPLE CARD'
+
+    if 'MERRICK BANK' in merchant_upper:
+        return 'MERRICK BANK'
+
+    # ============================================================================
+    # ADDITIONAL FINANCIAL SERVICES (added based on 1441 diagnostic)
+    # ============================================================================
+
+    # Treasury Direct: appears as ``TREASURY DIRECT'', ``TREASURYDIRECT'',
+    # ``US TREASURY''. Collapse so the merchant chart shows one row.
+    if 'TREASURY' in merchant_upper and ('DIRECT' in merchant_upper or merchant_upper.startswith('US TREASURY')):
+        return 'TREASURY DIRECT'
+
+    # GM Financial -- already collapsed below in Auto Loans section, but
+    # add here too in case the Auto block hasn't loaded yet (defensive).
+    if 'GM FINANCIAL' in merchant_upper:
+        return 'GM FINANCIAL'
+
+    # New York Life: ``NYLIFE FINANCIAL INSPAYMENT'', ``NEW YORK LIFE'' etc.
+    if 'NYLIFE' in merchant_upper or 'NEW YORK LIFE' in merchant_upper:
+        return 'NEW YORK LIFE'
+
     # Student Loans
     if 'DEPT EDUCATION' in merchant_upper or 'DEPARTMENT OF EDUCATION' in merchant_upper or 'ED FINANCIAL' in merchant_upper:
         return 'DEPT OF EDUCATION (STUDENT LOANS)'

--- a/01_Analysis/00-Scripts/analytics/txn_setup/07-consolidation-summary.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/07-consolidation-summary.py
@@ -17,6 +17,66 @@ print("="*100)
 print("\nApplying merchant name standardization...")
 combined_df['merchant_consolidated'] = combined_df['merchant_name'].apply(standardize_merchant_name)
 
+# ---------------------------------------------------------------------------
+# SMART UNKNOWN-MERCHANT FALLBACK
+# ---------------------------------------------------------------------------
+# When merchant_name is genuinely empty (ATM withdrawals, bank fees, internal
+# transfers), the consolidator returns 'UNKNOWN MERCHANT'. On personal accounts
+# this typically runs ~5-10%; on business it can hit 40% (lots of ACH activity
+# without a recognizable merchant). Lumping them all under one bucket distorts
+# the top-merchant charts and the leakage analysis.
+#
+# Re-label these rows based on the transaction_type column (PIN / SIG / ACH /
+# CHK / ATM / FEE / etc.) so the chart shows what those transactions actually
+# are -- ``ATM WITHDRAWAL'' / ``BANK FEE'' / ``ACH TRANSFER'' / etc. -- rather
+# than one giant ``UNKNOWN MERCHANT'' bucket. This is purely cosmetic relabeling;
+# downstream tagging (tag_competitors, financial_services) treats the new
+# labels exactly the same as Unknown (they don't match any competitor pattern).
+# ---------------------------------------------------------------------------
+_unknown_mask = combined_df['merchant_consolidated'] == 'UNKNOWN MERCHANT'
+_n_unknown_before = int(_unknown_mask.sum())
+if _n_unknown_before > 0 and 'transaction_type' in combined_df.columns:
+    _ttype = combined_df.loc[_unknown_mask, 'transaction_type'].astype(str).str.upper().str.strip()
+
+    # Map common transaction_type codes to descriptive labels. Unknown values
+    # fall through to the generic ``UNKNOWN MERCHANT'' label so we don't
+    # silently invent buckets for codes we haven't seen.
+    def _label_for_ttype(t):
+        if not t or t in ('NAN', 'NONE', ''):
+            return 'UNKNOWN MERCHANT'
+        if 'ATM' in t:
+            return 'ATM WITHDRAWAL'
+        if 'FEE' in t or t in ('SC', 'NSF', 'OD'):
+            return 'BANK FEE'
+        if 'ACH' in t:
+            return 'ACH TRANSFER (NO MERCHANT)'
+        if 'CHK' in t or 'CHECK' in t or t == 'CK':
+            return 'CHECK (NO MERCHANT)'
+        if 'XFER' in t or 'TRANSFER' in t or t in ('TR', 'TRF'):
+            return 'INTERNAL TRANSFER'
+        if t in ('PIN', 'SIG', 'POS', 'DEB'):
+            return 'POS TRANSACTION (NO MERCHANT)'
+        if 'DEP' in t or 'DEPOSIT' in t:
+            return 'DEPOSIT (NO MERCHANT)'
+        if 'WD' in t or 'WTHD' in t or 'WITHDRAW' in t:
+            return 'WITHDRAWAL (NO MERCHANT)'
+        return 'UNKNOWN MERCHANT'
+
+    combined_df.loc[_unknown_mask, 'merchant_consolidated'] = _ttype.apply(_label_for_ttype)
+
+    _n_unknown_after = int((combined_df['merchant_consolidated'] == 'UNKNOWN MERCHANT').sum())
+    _relabeled = _n_unknown_before - _n_unknown_after
+    print(f"  Smart Unknown fallback: relabeled {_relabeled:,} rows by transaction_type")
+    print(f"  ({_n_unknown_before:,} unknowns before -> {_n_unknown_after:,} truly unknown after)")
+    if _relabeled > 0:
+        # Show the breakdown so the user can audit
+        _new_labels = (
+            combined_df.loc[_unknown_mask, 'merchant_consolidated']
+            .value_counts().head(10)
+        )
+        for _label, _count in _new_labels.items():
+            print(f"     {_count:>10,}  {_label}")
+
 # Calculate consolidation impact
 original_count = combined_df['merchant_name'].nunique()
 consolidated_count = combined_df['merchant_consolidated'].nunique()

--- a/01_Analysis/00-Scripts/analytics/txn_setup/09-oddd-account-type.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/09-oddd-account-type.py
@@ -122,14 +122,41 @@ if not SKIP_COMBINE:
 
     def _save_cache():
         try:
-            # Save to local temp first (fast), then move to network
-            _tmp = Path(tempfile.mktemp(suffix='.parquet'))
+            # Ensure parent directory exists (first-run-for-client case).
+            PARQUET_CACHE.parent.mkdir(parents=True, exist_ok=True)
+
+            # Write to a sibling temp file on the SAME filesystem as the
+            # final destination, then atomic rename. Using the OS tempdir
+            # (/tmp or C:\Users\...\Temp) causes shutil.move to do a
+            # slow cross-filesystem copy+delete for a 500MB Parquet --
+            # the dest is on the M: network share in production. A same-
+            # filesystem rename is atomic, takes <1 second.
+            import uuid as _uuid
+            _tmp = PARQUET_CACHE.with_suffix(f'.{_uuid.uuid4().hex[:8]}.tmp')
             combined_df.to_parquet(_tmp, index=False, engine='pyarrow')
-            shutil.move(str(_tmp), str(PARQUET_CACHE))
+            # Atomic rename; if the destination exists, overwrite it.
+            try:
+                _tmp.replace(PARQUET_CACHE)
+            except OSError:
+                # Fallback for edge cases (replace not atomic across some
+                # network filesystems): copy + unlink
+                import shutil as _shutil
+                _shutil.copy2(str(_tmp), str(PARQUET_CACHE))
+                try:
+                    _tmp.unlink()
+                except OSError:
+                    pass
+
             _cache_mb = PARQUET_CACHE.stat().st_size / 1024 / 1024
             print(f"  Parquet cache saved: {PARQUET_CACHE.name} ({_cache_mb:.0f} MB)")
         except Exception as _e:
-            print(f"  WARNING: Could not save Parquet cache: {_e}")
+            print(f"  WARNING: Could not save Parquet cache: {type(_e).__name__}: {_e}")
+            # Clean up stray temp on failure
+            try:
+                for _stray in PARQUET_CACHE.parent.glob(f"{PARQUET_CACHE.stem}.*.tmp"):
+                    _stray.unlink()
+            except Exception:
+                pass
 
     print(f"\nSaving Parquet cache in background (analysis continues)...")
     _cache_thread = threading.Thread(target=_save_cache, daemon=True)

--- a/01_Analysis/00-Scripts/analytics/txn_wrapper.py
+++ b/01_Analysis/00-Scripts/analytics/txn_wrapper.py
@@ -76,7 +76,11 @@ class ChartCapture:
         return self
 
     def __exit__(self, *args):
-        # Capture any remaining open figures
+        # Capture any remaining open figures left behind when a script ended
+        # without calling plt.show() (or crashed mid-render). Savefig errors
+        # here used to be DEBUG-level silent drops -- upgraded to WARNING so
+        # partial-chart losses don't disappear from the run report.
+        self.save_errors: list[str] = []
         for fig_num in plt.get_fignums():
             fig = plt.figure(fig_num)
             self._fig_count += 1
@@ -87,7 +91,9 @@ class ChartCapture:
                             facecolor="white", edgecolor="none")
                 self.captured.append(path)
             except Exception as exc:
-                logger.debug("Failed to save chart {name}: {err}", name=name, err=exc)
+                msg = f"{name}: {type(exc).__name__}: {str(exc)[:120]}"
+                logger.warning("Chart save failed in __exit__: {msg}", msg=msg)
+                self.save_errors.append(msg)
         plt.close("all")
 
         # Restore original plt.show

--- a/01_Analysis/00-Scripts/analytics/txn_wrapper.py
+++ b/01_Analysis/00-Scripts/analytics/txn_wrapper.py
@@ -137,6 +137,15 @@ def _execute_scripts(script_dir: Path, namespace: dict[str, Any],
     # the next section and any subsequent `Path(__file__).parent` is wrong.
     saved_file = namespace.get("__file__")
 
+    # Per-script skip patterns (prefix-match on script name). Configured by
+    # earlier cells to prune duplicate / optional cells without deleting code.
+    # Example: competition/01 sets SKIP_SCRIPT_PATTERNS=['60_', '61_', '62_']
+    # when SLIDE_MODE='standard' to drop the parallel banks-only / core-
+    # competition variants (each a ~5-slide duplicate view of 07-09). Keeps
+    # the deep-dive cells available for clients who want them via
+    # SLIDE_MODE='deep'.
+    skip_patterns = namespace.get("SKIP_SCRIPT_PATTERNS", [])
+
     for script_path in scripts:
         script_name = script_path.stem
 
@@ -144,6 +153,14 @@ def _execute_scripts(script_dir: Path, namespace: dict[str, Any],
         # to bail out early (e.g., "No MCC data available")
         if namespace.get("SKIP_SECTION"):
             logger.info("  TXN skipping: {name} (SKIP_SECTION set)", name=script_name)
+            continue
+
+        # Check script-level skip patterns
+        if any(script_name.startswith(pat) for pat in skip_patterns):
+            logger.info(
+                "  TXN skipping: {name} (matches SKIP_SCRIPT_PATTERNS)",
+                name=script_name,
+            )
             continue
 
         logger.info("  TXN executing: {name}", name=script_name)
@@ -186,8 +203,10 @@ def _execute_scripts(script_dir: Path, namespace: dict[str, Any],
     else:
         namespace["__file__"] = saved_file
 
-    # Reset skip flag for next section
+    # Reset skip flags for next section -- each section controls its own
+    # pruning via its own 01_*.py setting SKIP_SCRIPT_PATTERNS.
     namespace.pop("SKIP_SECTION", None)
+    namespace.pop("SKIP_SCRIPT_PATTERNS", None)
 
     return all_charts, failures
 

--- a/01_Analysis/00-Scripts/analytics/txn_wrapper.py
+++ b/01_Analysis/00-Scripts/analytics/txn_wrapper.py
@@ -517,10 +517,29 @@ def prepare_shared_namespace(ctx: PipelineContext) -> dict[str, Any]:
     df = namespace.get("combined_df")
     if df is not None and hasattr(df, "__len__"):
         row_count = len(df)
-    logger.info(
-        "txn_setup complete: {rows:,} rows in {sec:.1f}s",
-        rows=row_count, sec=elapsed,
-    )
+
+    # Memory telemetry. When the campaign section later hits ``bad
+    # allocation'' / ``not enough free memory for image buffer'' (issue
+    # #92), this baseline helps diagnose whether setup itself is the
+    # problem or something downstream is leaking. psutil is optional.
+    _rss_mb = None
+    try:
+        import psutil as _psutil
+        _rss_mb = _psutil.Process().memory_info().rss / (1024 * 1024)
+    except Exception:
+        pass
+
+    if _rss_mb is not None:
+        logger.info(
+            "txn_setup complete: {rows:,} rows in {sec:.1f}s (process RSS: {rss:,.0f} MB)",
+            rows=row_count, sec=elapsed, rss=_rss_mb,
+        )
+        namespace["_txn_setup_rss_mb"] = _rss_mb
+    else:
+        logger.info(
+            "txn_setup complete: {rows:,} rows in {sec:.1f}s",
+            rows=row_count, sec=elapsed,
+        )
 
     return namespace
 

--- a/01_Analysis/00-Scripts/analytics/txn_wrapper.py
+++ b/01_Analysis/00-Scripts/analytics/txn_wrapper.py
@@ -99,18 +99,37 @@ class ChartCapture:
 # Script executor -- runs scripts in a shared namespace
 # ---------------------------------------------------------------------------
 
+@dataclass
+class ScriptFailure:
+    """One failed script execution. Surfaced so the summary shows real status."""
+    script_name: str
+    error_type: str
+    error_msg: str
+
+
 def _execute_scripts(script_dir: Path, namespace: dict[str, Any],
-                     chart_dir: Path, section_prefix: str) -> list[Path]:
+                     chart_dir: Path, section_prefix: str
+                     ) -> tuple[list[Path], list[ScriptFailure]]:
     """Execute all .py scripts in a directory in sorted order, sharing a namespace.
 
-    Returns list of captured chart paths.
+    Returns:
+        (captured_charts, failures). Failures used to be silently logged-only,
+        which made the TXN summary report ``22/22 OK'' when there were actual
+        crashes. Callers MUST propagate failures to the section-level summary
+        so users see them.
     """
     scripts = sorted(script_dir.glob("*.py"))
     if not scripts:
         logger.warning("No .py scripts found in {dir}", dir=script_dir)
-        return []
+        return [], []
 
     all_charts: list[Path] = []
+    failures: list[ScriptFailure] = []
+
+    # Preserve the parent namespace's __file__ so we can restore it after this
+    # batch finishes. Without this, the last script's __file__ leaks into
+    # the next section and any subsequent `Path(__file__).parent` is wrong.
+    saved_file = namespace.get("__file__")
 
     for script_path in scripts:
         script_name = script_path.stem
@@ -126,19 +145,45 @@ def _execute_scripts(script_dir: Path, namespace: dict[str, Any],
         with ChartCapture(chart_dir, prefix=f"{section_prefix}_{script_name}") as capture:
             try:
                 code = script_path.read_text(encoding="utf-8")
-                # Set __file__ so scripts can resolve relative paths
                 namespace["__file__"] = str(script_path)
                 exec(compile(code, str(script_path), "exec"), namespace)
             except Exception as exc:
                 logger.error("  TXN script failed: {name}: {err}", name=script_name, err=exc)
-                continue
+                failures.append(ScriptFailure(
+                    script_name=script_name,
+                    error_type=type(exc).__name__,
+                    error_msg=str(exc)[:200],
+                ))
+                # Do NOT `continue` here -- falling through lets the ChartCapture
+                # __exit__ run, which closes any partially-created figures. The
+                # next loop iteration proceeds to the next script.
 
         all_charts.extend(capture.captured)
+
+        # Memory hygiene between scripts. Campaign section was hitting ``bad
+        # allocation'' and ``not enough free memory for image buffer'' because
+        # matplotlib figures accumulated across 30+ scripts. plt.close('all')
+        # + gc.collect() at the boundary releases those buffers.
+        try:
+            plt.close("all")
+        except Exception:
+            pass
+        try:
+            import gc
+            gc.collect()
+        except Exception:
+            pass
+
+    # Restore/clean up __file__ so it doesn't leak to the next section
+    if saved_file is None:
+        namespace.pop("__file__", None)
+    else:
+        namespace["__file__"] = saved_file
 
     # Reset skip flag for next section
     namespace.pop("SKIP_SECTION", None)
 
-    return all_charts
+    return all_charts, failures
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +234,9 @@ class TXNSectionWrapper(AnalysisModule):
         self.section = "transaction"
         self.execution_order = meta.get("order", 500)
         self.required_columns = ()  # TXN scripts handle their own validation
+        # Populated by .run() so runner.py can print real per-section status
+        # instead of always saying ``OK''. Was a silent ERROR-log-only before.
+        self.failures: list[ScriptFailure] = []
 
     def validate(self, ctx: PipelineContext) -> list[str]:
         """Check that section directory exists and has scripts."""
@@ -228,12 +276,22 @@ class TXNSectionWrapper(AnalysisModule):
             setup_dir = self.section_dir.parent / "txn_setup"
             if setup_dir.exists() and "_txn_setup_done" not in namespace:
                 logger.info("  Running txn_setup...")
-                _execute_scripts(setup_dir, namespace, ctx.paths.charts_dir, "txn_setup")
+                _setup_charts, _setup_failures = _execute_scripts(
+                    setup_dir, namespace, ctx.paths.charts_dir, "txn_setup",
+                )
+                if _setup_failures:
+                    logger.error(
+                        "txn_setup had {n} failed scripts: {names}",
+                        n=len(_setup_failures),
+                        names=", ".join(f.script_name for f in _setup_failures),
+                    )
                 namespace["_txn_setup_done"] = True
 
         # Run section scripts
         chart_dir = ctx.paths.charts_dir / self.section_name
-        charts = _execute_scripts(self.section_dir, namespace, chart_dir, self.section_name)
+        charts, self.failures = _execute_scripts(
+            self.section_dir, namespace, chart_dir, self.section_name,
+        )
 
         # Propagate new variables back to shared namespace so later sections
         # can use them (e.g., GEN_COLORS from general, demo_df, acct_txn_counts).
@@ -255,7 +313,18 @@ class TXNSectionWrapper(AnalysisModule):
                 success=True,
             ))
 
-        logger.info("TXN section {name}: {n} charts captured", name=self.section_name, n=len(results))
+        if self.failures:
+            logger.warning(
+                "TXN section {name}: {n} charts captured, {f} script(s) FAILED ({names})",
+                name=self.section_name, n=len(results),
+                f=len(self.failures),
+                names=", ".join(f.script_name for f in self.failures),
+            )
+        else:
+            logger.info(
+                "TXN section {name}: {n} charts captured",
+                name=self.section_name, n=len(results),
+            )
         return results
 
 
@@ -400,7 +469,19 @@ def prepare_shared_namespace(ctx: PipelineContext) -> dict[str, Any]:
         return namespace
 
     logger.info("Running txn_setup once for all sections...")
-    _execute_scripts(setup_dir, namespace, ctx.paths.charts_dir, "txn_setup")
+    _charts, setup_failures = _execute_scripts(
+        setup_dir, namespace, ctx.paths.charts_dir, "txn_setup",
+    )
+    if setup_failures:
+        # txn_setup failures are CRITICAL -- combined_df may not exist and
+        # every downstream section will fail. Log loudly but keep going so
+        # later diagnostics still run and the user can see the chain.
+        logger.error(
+            "txn_setup FAILURES ({n}): {names} -- downstream sections likely broken",
+            n=len(setup_failures),
+            names=", ".join(f.script_name for f in setup_failures),
+        )
+        namespace["_txn_setup_failures"] = setup_failures
     namespace["_txn_setup_done"] = True
 
     # Optimize memory after the heavy data loading

--- a/01_Analysis/00-Scripts/diagnose_txn_files.py
+++ b/01_Analysis/00-Scripts/diagnose_txn_files.py
@@ -1,0 +1,188 @@
+"""
+TXN File Diagnostic
+===================
+Finds malformed lines in the raw transaction CSVs that crash pandas
+with ``Error tokenizing data. C error: Expected N fields...''.
+
+Run from the work machine (Windows) where M: is mapped:
+
+    python 01_Analysis/00-Scripts/diagnose_txn_files.py --csm JamesG --client 1441
+
+Output: prints, per file, whether it loads cleanly. For files that
+fail, prints the raw text of the offending line(s) and 2 lines of
+context above and below so the malformation is visible. Does NOT
+modify any data -- this is a read-only investigation.
+
+Why this script exists
+----------------------
+The pipeline runs `pd.read_csv` with default ``on_bad_lines='error'''
+which raises on the FIRST malformed line and gives no filename
+context. That makes a single-row error look like the whole pipeline
+is broken. This script isolates the problem so the source CSV can
+be fixed at its origin (rather than skipped silently in the loader).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+
+def find_ars_base() -> Path:
+    candidates = [
+        Path(r"M:\ARS"),
+        Path("/Volumes/M/ARS"),
+    ]
+    for p in candidates:
+        if p.exists():
+            return p
+    raise SystemExit("ERROR: could not locate ARS base (tried M:\\ARS and /Volumes/M/ARS)")
+
+
+def detect_separator(filepath: Path) -> str:
+    """Match the loader's logic: .csv => comma, anything else => tab."""
+    return "," if filepath.suffix.lower() == ".csv" else "\t"
+
+
+def diagnose_file(filepath: Path, expected_columns: int = 13, sep: str | None = None) -> dict:
+    """Walk every line of `filepath`, count fields, return a report."""
+    if sep is None:
+        sep = detect_separator(filepath)
+
+    report = {
+        "file": filepath.name,
+        "size_mb": filepath.stat().st_size / (1024 * 1024),
+        "sep": "TAB" if sep == "\t" else "COMMA",
+        "total_lines": 0,
+        "header_field_count": None,
+        "bad_lines": [],   # list of (lineno, field_count, raw_text)
+    }
+
+    # Read with the csv module (matches pandas's underlying tokenizer
+    # closely enough to catch the same defects: stray separators,
+    # unmatched quotes, embedded newlines).
+    with filepath.open("r", encoding="utf-8", errors="replace", newline="") as fh:
+        reader = csv.reader(fh, delimiter=sep)
+        for lineno, row in enumerate(reader, start=1):
+            report["total_lines"] = lineno
+            if lineno == 1:
+                # First line is the header in production files
+                report["header_field_count"] = len(row)
+                continue
+            # Pipeline expects 13 columns; tolerate 12 (a known FNB
+            # variant per the 1776 log) and flag everything else.
+            if len(row) not in (expected_columns, expected_columns - 1):
+                report["bad_lines"].append(
+                    (lineno, len(row), sep.join(row[:5]) + (" ..." if len(row) > 5 else ""))
+                )
+                if len(report["bad_lines"]) >= 20:
+                    # Stop early -- 20 examples is enough to characterize
+                    # the pattern and avoids huge logs on systemic errors.
+                    break
+    return report
+
+
+def fetch_context(filepath: Path, lineno: int, around: int = 2) -> list[tuple[int, str]]:
+    """Return (line_number, raw_text) tuples for `around` lines on each
+    side of `lineno`, plus `lineno` itself. Read raw -- do NOT csv-parse,
+    so we see the actual bytes that confused the parser."""
+    out: list[tuple[int, str]] = []
+    lo = max(1, lineno - around)
+    hi = lineno + around
+    with filepath.open("r", encoding="utf-8", errors="replace") as fh:
+        for current, line in enumerate(fh, start=1):
+            if current < lo:
+                continue
+            if current > hi:
+                break
+            out.append((current, line.rstrip("\n")))
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--csm", required=True, help="CSM folder name (e.g. JamesG)")
+    parser.add_argument("--client", required=True, help="Client ID (e.g. 1441)")
+    parser.add_argument("--expected-columns", type=int, default=13)
+    parser.add_argument("--context", type=int, default=2,
+                        help="Raw lines to show on each side of bad line (default 2)")
+    args = parser.parse_args()
+
+    ars_base = find_ars_base()
+    txn_dir = ars_base / "00_Formatting" / "02-Data-Ready for Analysis" / "TXN Files" / args.csm / args.client
+    if not txn_dir.exists():
+        print(f"ERROR: TXN directory not found: {txn_dir}")
+        return 1
+
+    files = sorted(
+        list(txn_dir.glob("*.csv"))
+        + list(txn_dir.glob("*.txt"))
+        + [p for p in txn_dir.iterdir() if p.is_dir() and p.name.isdigit() for q in p.iterdir() if q.suffix.lower() in (".csv", ".txt")]
+    )
+    if not files:
+        print(f"ERROR: no .csv or .txt files in {txn_dir}")
+        return 1
+
+    print()
+    print("=" * 78)
+    print(f"  TXN FILE DIAGNOSTIC -- {args.csm} / client {args.client}")
+    print(f"  Path: {txn_dir}")
+    print(f"  Files: {len(files)}  Expected columns: {args.expected_columns}")
+    print("=" * 78)
+
+    overall_bad = 0
+    for fp in files:
+        print()
+        report = diagnose_file(fp, expected_columns=args.expected_columns)
+        size_str = f"{report['size_mb']:.0f} MB"
+        line_str = f"{report['total_lines']:,}"
+        if not report["bad_lines"]:
+            print(f"  OK   {fp.name}  ({size_str}, {line_str} lines, header={report['header_field_count']} cols, {report['sep']})")
+            continue
+
+        overall_bad += 1
+        print(f"  BAD  {fp.name}  ({size_str}, {line_str} lines, header={report['header_field_count']} cols, {report['sep']})")
+        print(f"       {len(report['bad_lines'])} malformed line(s) (showing first {min(len(report['bad_lines']), 10)}):")
+        for lineno, n_fields, preview in report["bad_lines"][:10]:
+            delta = n_fields - args.expected_columns
+            sign = "+" if delta > 0 else ""
+            print(f"         line {lineno:>7}: {n_fields} fields ({sign}{delta} vs expected)  preview: {preview[:100]}")
+
+        # For the FIRST bad line in this file, also show raw context
+        if report["bad_lines"]:
+            first_bad_lineno = report["bad_lines"][0][0]
+            print(f"       Raw context around line {first_bad_lineno}:")
+            for lno, raw in fetch_context(fp, first_bad_lineno, around=args.context):
+                marker = " >>> " if lno == first_bad_lineno else "     "
+                # Clip very long lines so the report stays readable
+                shown = raw if len(raw) <= 240 else (raw[:237] + "...")
+                print(f"         {marker}{lno:>7}: {shown}")
+
+    print()
+    print("=" * 78)
+    if overall_bad == 0:
+        print("  All files parsed cleanly. No malformed lines detected.")
+    else:
+        print(f"  {overall_bad} of {len(files)} file(s) have malformed lines.")
+        print()
+        print("  WHAT TO DO:")
+        print("    1. Open each BAD file in a text editor (notepad++ or VS Code).")
+        print("    2. Jump to the line numbers shown above.")
+        print("    3. Inspect the offending row -- common causes:")
+        print("       * Stray comma INSIDE a merchant name (e.g. ``SMITH, JOHN'')")
+        print("       * Unmatched double-quote (`` not closed before EOL)")
+        print("       * Embedded newline inside a field (line continuation)")
+        print("    4. Fix the source row, save the file, re-run the pipeline.")
+        print()
+        print("  If the same kind of malformation appears in EVERY monthly file,")
+        print("  the bug is upstream in the report-generation system that produces")
+        print("  these CSVs -- raise it with whoever maintains that system.")
+    print("=" * 78)
+    return 0 if overall_bad == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/01_Analysis/00-Scripts/output/deck_builder.py
+++ b/01_Analysis/00-Scripts/output/deck_builder.py
@@ -1898,9 +1898,19 @@ def build_deck(ctx: PipelineContext) -> Path | None:
 
     # Build the PPTX
     ctx.paths.pptx_dir.mkdir(parents=True, exist_ok=True)
-    # Detect product type from slide IDs to avoid overwriting different runs
-    _has_ars = any(not getattr(s, "slide_id", "").startswith("TXN-") for s in final_slides)
-    _has_txn = any(getattr(s, "slide_id", "").startswith("TXN-") for s in final_slides)
+    # Detect product type from the ORIGINAL AnalysisResult objects in
+    # ctx.all_slides. Previously this checked final_slides (SlideContent)
+    # which has no slide_id attribute -- getattr(..., "") always returned
+    # "", so _has_txn was always False and every deck got mislabeled
+    # ``{client}_{month}_ars_deck.pptx'' even on pure-TXN runs (issue:
+    # 1776 2026.04 run produced 328 TXN slides but was named _ars_deck).
+    _original = getattr(ctx, "all_slides", []) or []
+    _has_ars = any(
+        not getattr(s, "slide_id", "").startswith("TXN-") for s in _original
+    )
+    _has_txn = any(
+        getattr(s, "slide_id", "").startswith("TXN-") for s in _original
+    )
     if _has_ars and _has_txn:
         _product_label = "combined"
     elif _has_txn:

--- a/01_Analysis/00-Scripts/runner.py
+++ b/01_Analysis/00-Scripts/runner.py
@@ -436,29 +436,63 @@ def run_txn(ctx: SharedContext) -> dict[str, SharedResult]:
             ars_ctx.results[wrapper.module_id] = results
             ars_ctx.all_slides.extend(results)
             n_slides = len(results)
-            section_results.append((wrapper.display_name, n_slides, "OK" if n_slides > 0 else "NO CHARTS"))
+            # Per-script failures (surfaced by txn_wrapper). Previously these
+            # were logged but never shown in the summary -- causing reports
+            # to claim ``22/22 OK'' when scripts had actually crashed.
+            script_failures = getattr(wrapper, "failures", None) or []
+            if script_failures:
+                status = f"OK ({len(script_failures)} script(s) failed)"
+            elif n_slides > 0:
+                status = "OK"
+            else:
+                status = "NO CHARTS"
+            section_results.append((
+                wrapper.display_name, n_slides, status, script_failures,
+            ))
             success_count += 1
-            logger.info("TXN section %s: %d slides", wrapper.section_name, n_slides)
+            logger.info(
+                "TXN section %s: %d slides, %d script failures",
+                wrapper.section_name, n_slides, len(script_failures),
+            )
         except Exception as exc:
             logger.error("TXN section %s failed: %s", wrapper.section_name, exc)
-            section_results.append((wrapper.display_name, 0, f"FAILED: {exc}"))
+            section_results.append((wrapper.display_name, 0, f"FAILED: {exc}", []))
             fail_count += 1
 
     # Print summary report
     if ctx.progress_callback:
         ctx.progress_callback("")
-        ctx.progress_callback("=" * 60)
+        ctx.progress_callback("=" * 72)
         ctx.progress_callback("  TXN ANALYSIS SUMMARY")
-        ctx.progress_callback("=" * 60)
-        for name, slides, status in section_results:
-            marker = "OK" if "OK" in status else "!!" if "FAIL" in status or "SKIP" in status else "--"
-            ctx.progress_callback(f"  [{marker}] {name:<30s} {slides:>3} slides  {status}")
-        ctx.progress_callback("-" * 60)
+        ctx.progress_callback("=" * 72)
+        total_script_failures = 0
+        for name, slides, status, script_failures in section_results:
+            if "FAIL" in status:
+                marker = "!!"
+            elif script_failures:
+                marker = "XX"  # section ran but had script-level failures
+            elif "SKIP" in status:
+                marker = "--"
+            elif "OK" in status:
+                marker = "OK"
+            else:
+                marker = "--"
+            ctx.progress_callback(
+                f"  [{marker}] {name:<30s} {slides:>3} slides  {status}"
+            )
+            # Indent each failed script under its section for quick triage
+            for f in script_failures:
+                total_script_failures += 1
+                ctx.progress_callback(
+                    f"         - {f.script_name}: {f.error_type}: {f.error_msg[:90]}"
+                )
+        ctx.progress_callback("-" * 72)
         ctx.progress_callback(
-            f"  Total: {success_count} OK, {fail_count} failed, "
+            f"  Total: {success_count} sections OK, {fail_count} sections failed, "
+            f"{total_script_failures} script(s) inside sections failed, "
             f"{len(ars_ctx.all_slides)} slides generated"
         )
-        ctx.progress_callback("=" * 60)
+        ctx.progress_callback("=" * 72)
 
     # Generate output (deck + excel) if slides exist
     if ars_ctx.all_slides:

--- a/01_Analysis/00-Scripts/runner.py
+++ b/01_Analysis/00-Scripts/runner.py
@@ -492,6 +492,31 @@ def run_txn(ctx: SharedContext) -> dict[str, SharedResult]:
             f"{total_script_failures} script(s) inside sections failed, "
             f"{len(ars_ctx.all_slides)} slides generated"
         )
+
+        # Deck-size budget warning. A client exec review should be
+        # 150 slides or fewer; if we're over, highlight which sections
+        # dominate so the user can decide whether to rerun with
+        # SLIDE_MODE=minimal or live with it.
+        import os as _os_budget
+        _slide_budget = int(_os_budget.environ.get("SLIDE_BUDGET", "150"))
+        _total_slides = len(ars_ctx.all_slides)
+        if _total_slides > _slide_budget:
+            ctx.progress_callback("")
+            ctx.progress_callback(
+                f"  NOTICE: {_total_slides} slides exceeds SLIDE_BUDGET ({_slide_budget})."
+            )
+            _heavy = sorted(
+                [(n, s) for n, s, _, _ in section_results if s > 15],
+                key=lambda x: -x[1],
+            )[:5]
+            if _heavy:
+                ctx.progress_callback(
+                    "  Largest sections: "
+                    + ", ".join(f"{n}={s}" for n, s in _heavy)
+                )
+            ctx.progress_callback(
+                "  Tip: set SLIDE_MODE=minimal (or =standard if already deep)"
+            )
         ctx.progress_callback("=" * 72)
 
     # Generate output (deck + excel) if slides exist

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -801,16 +801,37 @@ async def run_schedule_now(schedule_id: str):
 
 
 if __name__ == "__main__":
+    import os as _os
     import socket
 
-    port = 8000
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        if s.connect_ex(("127.0.0.1", port)) == 0:
-            print(f"\n  ERROR: Port {port} is already in use.")
-            print(f"  Kill the other process or use a different port:")
-            print(f"    netstat -ano | findstr :{port}")
+    # Auto-pick a free port so a second instance doesn't leave the user
+    # staring at the wrong tab wondering why the pipeline isn't moving
+    # (the root cause of issue #90 yesterday). Start at 8000, walk up to
+    # 8010, then fail with a clear message.
+    preferred_port = int(_os.environ.get("ARS_UI_PORT", "8000"))
+
+    def _is_port_free(p):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex(("127.0.0.1", p)) != 0
+
+    port = preferred_port
+    if not _is_port_free(port):
+        print(f"\n  NOTE: Port {port} is already in use (another UI instance?).")
+        for alt in range(preferred_port + 1, preferred_port + 11):
+            if _is_port_free(alt):
+                port = alt
+                print(f"  Using port {port} instead.")
+                break
+        else:
+            print(f"\n  ERROR: Ports {preferred_port}-{preferred_port + 10} all in use.")
+            print(f"  Kill the other process or set ARS_UI_PORT=<n>:")
+            print(f"    netstat -ano | findstr :{preferred_port}")
             print(f"    taskkill /PID <pid> /F")
             sys.exit(1)
+
+    # Remind users that SLIDE_MODE gates deck size. Forwarded to the
+    # analyze subprocess through the environment.
+    slide_mode = _os.environ.get("SLIDE_MODE", "standard")
 
     print()
     print("=" * 60)
@@ -819,7 +840,9 @@ if __name__ == "__main__":
     print(f"  Config:      {CONFIG_PATH} {'[OK]' if CONFIG_PATH.exists() else '[NOT FOUND]'}")
     print(f"  CSMs:        {get_csm_list() or '[none configured]'}")
     print(f"  index.html:  {Path(__file__).parent / 'index.html'} {'[OK]' if (Path(__file__).parent / 'index.html').exists() else '[NOT FOUND]'}")
-    print(f"  http://localhost:{port}")
+    print(f"  SLIDE_MODE:  {slide_mode}  (env SLIDE_MODE=deep|standard|minimal)")
+    print(f"  URL:         http://localhost:{port}")
+    print(f"  PID:         {_os.getpid()}")
     print("=" * 60)
     print()
 

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -530,18 +530,28 @@ async def start_run(
             cmd = [sys.executable, "-u", str(analysis_run),
                    "--month", month, "--csm", csm, "--client", client_id,
                    "--product", product]
+            # Forward SLIDE_MODE and SLIDE_BUDGET so UI-set deck-size
+            # controls reach the analysis subprocess. Without this, the
+            # child inherits parent env but ARS_UI_PORT and similar
+            # wrapper-only vars can overwrite intended values.
+            import os as _env_os
+            _run_env = _env_os.environ.copy()
+            _run_env["PYTHONUNBUFFERED"] = "1"  # belt+braces with -u
             proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 text=True, encoding="utf-8", errors="replace",
                 bufsize=1,
                 cwd=str(analysis_run.parent),
+                env=_run_env,
             )
+            runs[run_id]["last_output_at"] = datetime.now().isoformat()
             for line in proc.stdout:
                 line = line.rstrip()
                 if run_id in runs:
                     runs[run_id]["log"].append(line)
                     runs[run_id]["current_step"] = line.strip()
+                    runs[run_id]["last_output_at"] = datetime.now().isoformat()
                     log_len = len(runs[run_id]["log"])
                     runs[run_id]["progress"] = min(95, log_len * 2)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Velocity Pipeline
 
-**ARS + Transaction analysis pipeline for credit union clients.**
+**ARS + Transaction analysis pipeline for credit union and bank clients.**
 
-Formats raw ODD data, runs 25 analysis modules, generates PowerPoint decks -- all from a web UI so CSMs never touch the command line.
+Formats raw ODD data, runs 25+ analysis modules, generates PowerPoint decks -- all from a web UI so CSMs never touch the command line.
 
 ## Folder Structure
 
@@ -21,7 +21,8 @@ M:\ARS\
 │   │   ├── charts/         # Chart styling and guards
 │   │   ├── output/         # Deck builder, Excel formatter, sample builder
 │   │   ├── pipeline/       # Pipeline runner, steps, context
-│   │   └── shared/         # Shared utilities, format_odd, helpers
+│   │   ├── shared/         # Shared utilities, format_odd, helpers
+│   │   └── diagnose_txn_files.py   # Standalone utility to find malformed CSVs
 │   └── 01_Completed_Analysis/  # Output (Excel, charts, JSON per client)
 │
 ├── 02_Presentations/       # Step 3: Generated PPTX output
@@ -29,7 +30,9 @@ M:\ARS\
 │
 ├── 03_Config/              # All configuration
 │   ├── ars_config.json     # Pipeline paths, CSM sources, extra file paths
-│   ├── clients_config.json # Per-client settings (22 credit unions)
+│   ├── clients_config.json # Per-client settings (multi-tenant)
+│   ├── branch_configs/     # Per-client branch number -> name maps
+│   │   └── {CLIENT_ID}.json
 │   └── settings.py         # Pydantic settings loader
 │
 ├── 04_Logs/                # Run logs and history
@@ -60,7 +63,7 @@ Or double-click `setup.bat`.
 
 Double-click `Start Here.bat` at `M:\ARS\`.
 
-Opens http://localhost:8000 in your browser. Keep the black window open while using the UI.
+Opens http://localhost:8000 in your browser. If port 8000 is taken (e.g., another instance is running), the server auto-walks 8001..8010 and prints the actual URL it's serving on. Set `ARS_UI_PORT=<n>` to override the starting port. Keep the black window open while using the UI.
 
 ### Command Line Usage
 
@@ -77,6 +80,7 @@ Flags:
 - `--with-workbook` -- also copy workbook files from R: drive
 - `--with-all` -- all three above
 - `--force` -- re-process even if output already exists
+- `--parallel N` -- format N clients in parallel
 
 **Run analysis + generate deck:**
 ```
@@ -86,15 +90,12 @@ python run.py --month 2026.04 --csm JamesG --client 1615 --product txn
 python run.py --month 2026.04 --csm JamesG --client 1615 --product combined
 ```
 
-Products:
-- `--product ars` -- ARS analysis only (default)
-- `--product txn` -- Transaction analysis only
-- `--product combined` -- Both ARS and TXN in one run
+Products (`--product`):
+- `ars` -- ARS analysis only (DEFAULT, recommended for standard client reviews)
+- `txn` -- Transaction analysis only (the big TXN deep-dive)
+- `combined` -- Both ARS and TXN in one deck (largest output)
 
-**Format with parallel processing:**
-```
-python run.py --month 2026.04 --parallel 4
-```
+**ARS is the main product.** TXN is additive -- explicitly opt-in via `--product txn` or `--product combined`. See issue #94 for the philosophy.
 
 **Run slide sampler (review all slide variants):**
 ```
@@ -103,6 +104,22 @@ python run_sampler.py --month 2026.04 --csm JamesG --client 1615
 python run_sampler.py --month 2026.04 --csm JamesG --client 1615 --section mailer
 python run_sampler.py --list-sections
 ```
+
+**Diagnose a malformed TXN CSV (read-only, no data changes):**
+```
+python 01_Analysis/00-Scripts/diagnose_txn_files.py --csm JamesG --client 1441
+```
+Walks every line of every TXN CSV for the client, finds rows that don't match the expected column count, and prints raw bytes around bad lines so you can see the malformation directly. Use when the loader crashes on a specific line number and you need to fix the source data.
+
+## Environment Variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `SLIDE_MODE` | `standard` | Controls TXN deck size. `standard` (~225 slides), `deep` (~335, full analyst audit), `minimal` (~100, lean exec one-pager). Honored by competition + campaign sections. |
+| `SLIDE_BUDGET` | `150` | If TXN summary exceeds this, prints a notice with the heaviest sections and suggests `SLIDE_MODE=minimal`. |
+| `CLIENT_TYPE` | auto-detect | `cu` or `bank`. Forces member/customer language across the deck. Auto-detected from `CLIENT_NAME` (CU markers: ``CREDIT UNION'', ``FCU'', ``FEDERAL CREDIT''). |
+| `ARS_UI_PORT` | `8000` | Starting port for the UI. Server walks `port..port+10` if the preferred port is in use. |
+| `CSM`, `MONTH`, `CLIENT_ID` | (from CLI) | TXN file path components. Set automatically by `run.py`. |
 
 ## Pipeline Flow
 
@@ -123,7 +140,12 @@ CSM Data Dump (M:\JamesG\OD Data Dumps\2026.04\)
                     01_Analysis/run.py
                       │
                       ├─ Load formatted ODD
-                      ├─ Run 25 analysis modules
+                      ├─ Run 25 ARS modules (always)
+                      ├─ Run 22 TXN sections   (if --product txn|combined)
+                      │     ├─ txn_setup runs ONCE (Parquet cache: 26 min ─► seconds on 2nd run)
+                      │     ├─ Each section's numbered scripts execute in shared namespace
+                      │     ├─ Per-script failures surfaced in summary table
+                      │     └─ Memory hygiene + telemetry between scripts
                       ├─ Generate charts (PNG)
                       ├─ Build PowerPoint deck
                       └─ Output:
@@ -159,7 +181,23 @@ Controls pipeline paths and CSM source folders:
 
 ### clients_config.json
 
-Per-client settings: IC rates, NSF fees, status codes, product codes, branch mappings. 22 credit unions configured.
+Per-client settings: IC rates, NSF fees, status codes, product codes, branch mappings. Multi-tenant.
+
+### branch_configs/{CLIENT_ID}.json
+
+Per-client branch number-to-name mapping. Without this file, section 10 (Branch Performance) shows numeric IDs instead of branch names. Sample template at `01_Analysis/00-Scripts/analytics/branch_txn/branch_config.sample.json`. Format:
+
+```json
+{
+  "1": "Main Office",
+  "2": "Downtown Branch",
+  "3": "West Branch"
+}
+```
+
+### CLIENT_CONFIGS (in competition/01_competitor_config.py)
+
+Per-client competitor patterns: `credit_unions`, `local_banks`, `custom`, plus the Fed District top-25 to load. Each new client onboards by adding an entry. The pipeline prints a loud warning if `CLIENT_ID` has no entry.
 
 ## Analysis Modules
 
@@ -175,35 +213,58 @@ Per-client settings: IC rates, NSF fees, status codes, product codes, branch map
 | Value | 1 | Revenue attribution |
 | Insights | 5 | Synthesis, recommendations, branch scorecard |
 
-### TXN (23 folders, 335 scripts -- transaction data)
+### TXN (22 sections, 340+ scripts -- transaction data)
 
 | Section | Scripts | What it analyzes |
-|---------|---------|------------------|
-| General | 29 | Portfolio KPIs, demographics, engagement |
-| Merchant | 14 | Top merchants, concentration, trends |
-| MCC Code | 15 | Category analysis |
-| Business Accts | 14 | Business merchant patterns |
-| Personal Accts | 14 | Personal merchant patterns |
-| Competition | 33 | Competitor detection, wallet share |
-| Financial Services | 19 | FI transaction leakage |
-| ICS Acquisition | 10 | Channel analysis |
-| Campaign | 43 | Campaign + cohort lift |
-| Branch TXN | 10 | Branch-level spend |
-| Transaction Type | 16 | PIN/SIG/ACH channels |
-| Product | 10 | Product-level spend |
-| Attrition TXN | 12 | Velocity-based risk |
-| Balance | 10 | Balance band analysis |
-| Interchange | 10 | PIN/SIG revenue |
-| Reg E Overdraft | 10 | Opt-in trends |
-| Payroll | 10 | Direct deposit detection |
-| Relationship | 10 | Cross-product holdings |
-| Segment Evolution | 8 | Engagement tier migration |
-| Retention | 7 | Churn/dormancy |
-| Engagement | 6 | Monthly tier classification |
-| Executive | 5 | KPI scorecard |
-| TXN Setup | 10 | Shared utilities, file config |
+|---------|--------:|------------------|
+| txn_setup (shared) | 10 | File loading, merchant consolidation, ODDD account-type tagging, Parquet cache |
+| general | 30 | Portfolio KPIs, demographics, engagement, **ARS swipe segmentation (3m vs 12m)** |
+| merchant | 14 | Top merchants, concentration, trends, volatility |
+| mcc_code | 15 | Category analysis |
+| business_accts | 14 | Business merchant patterns |
+| personal_accts | 14 | Personal merchant patterns |
+| competition | 35 | Competitor detection, wallet share, **multi-competitor count distribution**, CU/bank audit (cell 69), detection diagnostic (cell 68) |
+| financial_services | 20 | FI transaction leakage, detection diagnostic (cell 20) |
+| ics_acquisition | 10 | Channel analysis |
+| campaign | 43 | Mailer + cohort lift |
+| branch_txn | 10 | Branch-level spend |
+| transaction_type | 16 | PIN/SIG/ACH channels |
+| product | 10 | Product-level spend |
+| attrition_txn | 12 | Velocity-based risk |
+| balance | 10 | Balance band analysis |
+| interchange | 10 | PIN/SIG revenue |
+| rege_overdraft | 10 | Opt-in trends |
+| payroll | 10 | Direct deposit detection, PFI scoring |
+| relationship | 10 | Cross-product holdings |
+| segment_evolution | 8 | Engagement tier migration |
+| retention | 7 | Churn/dormancy |
+| engagement | 6 | Monthly tier classification |
+| executive | 5 | KPI scorecard |
 
 TXN scripts are wired into the pipeline via `txn_wrapper.py`. Run with `--product txn` or `--product combined`.
+
+### Diagnostic Cells (always run, not pruned by SLIDE_MODE)
+
+| Cell | What it shows |
+|---|---|
+| `competition/68_detection_diagnostic.py` | Per-category txn counts, top merchants per category, top unmatched financial keyword merchants |
+| `competition/69_cu_bank_audit.py` | Per-pattern audit of every configured CU + local bank, plus top untagged FI-like merchants |
+| `financial_services/20_detection_diagnostic.py` | Per-category counts, brand-root audit (Coinbase / Robinhood / Fidelity / Schwab / Vanguard) |
+
+## Pipeline Hardening (PR #93 highlights)
+
+- **Per-script failure surfacing.** Cell crashes inside a section used to be logged-only and the summary still said `OK`. The TXN summary now lists every failed script with error type + truncated message under its parent section.
+- **Content-aware delimiter detection.** TXN CSVs that are TAB-delimited but named `.csv` (and vice-versa) load correctly; loader sniffs the first 8 KB.
+- **Surviving-header-row removal.** Files with a metadata banner before the actual header (header survives `skiprows=1` and pollutes data) are now detected and skipped.
+- **Smart Unknown Merchant fallback.** ATMs / fees / ACH transfers / checks no longer all collapse to one ``UNKNOWN MERCHANT'' bucket; they get re-labeled by `transaction_type`.
+- **Carrier-prefix stripping.** Merchant strings like `ACH CREDIT SESLOC CREDIT UNION 805-555` are normalized to `SESLOC CREDIT UNION` so prefix-matching in `tag_competitors` works for CUs / local banks (not just for hand-coded brands like VENMO / PAYPAL).
+- **Memory hygiene between scripts.** `plt.close('all')` + `gc.collect()` between scripts prevents the campaign section memory cluster.
+- **Parquet cache status block.** Always-on HIT / MISS / NO CACHE block at the start of every TXN run -- explains why the run is slow (or fast).
+- **Atomic Parquet save.** Sibling-file write + `Path.replace()` instead of cross-filesystem `shutil.move` -- 30-60s save becomes <1s.
+- **Universal title/subtitle layout.** `GEN_TITLE_Y` / `GEN_SUBTITLE_Y` / `GEN_TOP_PAD` constants in general theme. Subtitles no longer overlap titles.
+- **Dynamic member/customer language.** `member_word()`, `MEMBER_NOUN_PLURAL`, etc. auto-pick CU vs bank terminology based on `CLIENT_NAME` or `CLIENT_TYPE` env var.
+- **ARS-standard swipe segmentation.** 7 buckets (`<1`, `1-5`, `6-10`, `11-15`, `16-20`, `21-25`, `25+`) with 3-month rolling AND 12-month averages, plus Stable/Active/Declining KPIs.
+- **UI auto-port.** Port-conflict no longer presents as an indefinite hang.
 
 ## Web UI
 
@@ -231,9 +292,7 @@ python run_sampler.py --month 2026.04 --csm JamesG --client 1615 --section maile
 python run_sampler.py --list-sections
 ```
 
-Output: one PPTX per section (`1615_2026.04_SAMPLER_MAILER.pptx`, etc.)
-
-Does NOT re-run analysis. Reads from existing chart PNGs in `01_Completed_Analysis/`.
+Output: one PPTX per section (`1615_2026.04_SAMPLER_MAILER.pptx`, etc.). Does NOT re-run analysis -- reads from existing chart PNGs in `01_Completed_Analysis/`.
 
 ## Slide Manifest
 
@@ -241,17 +300,19 @@ Does NOT re-run analysis. Reads from existing chart PNGs in `01_Completed_Analys
 
 ## Development
 
-- **Develop on Mac**, pipeline runs on **Windows work PC at M:\ARS\**
-- **GitHub** is the bridge -- push from Mac, download ZIP on work PC
-- Git does not work on the M: drive (network share ownership issue). Use ZIP downloads.
+- **Develop on Mac**, pipeline runs on **Windows work PC at M:\\ARS\\**
+- **GitHub** is the bridge -- push from Mac, `git pull` (or ZIP download) on work PC
+- Git can be flaky on the M: drive (network share ownership). Falling back to ZIP downloads is fine.
 - CSI brand: orange `#F15D22`, navy `#00274C`, gold `#FBAE40`, Montserrat font
 
 ## Tech Stack
 
 - Python 3.x
 - FastAPI + Uvicorn (web server)
-- Pandas (data manipulation)
-- Matplotlib (chart generation)
+- Pandas + NumPy (data manipulation)
+- Matplotlib + Seaborn (chart generation)
 - python-pptx (PowerPoint generation)
 - openpyxl / xlsxwriter (Excel I/O)
+- pyarrow (Parquet cache)
 - loguru (logging)
+- psutil (memory telemetry, optional)


### PR DESCRIPTION
## Summary

Addresses everything raised in #92 (run log review) plus additional items spotted during the deep dive. Seven atomic commits, all on a branch so they can be reverted cleanly if anything regresses.

## Commits

| # | Commit | What it fixes |
|---|---|---|
| 1 | ``e2ddac4`` | txn_wrapper: surface silent script failures + memory hygiene |
| 2 | ``81207f8`` | executive/05: remove hardcoded ``/private/tmp`` Mac path |
| 3 | ``9cefdfb`` | Four per-section script crashes (attrition, payroll x2, merchant) |
| 4 | ``b8bb8a5`` | Parquet cache status, branch_config lookup, chart-save warnings |
| 5 | ``021969d`` | SLIDE_MODE: deck size control (343 -> ~225 default) |
| 6 | ``74a599a`` | Slide budget, memory telemetry, UI auto-port |
| 7 | ``97c6cc3`` | Parquet save safety, subprocess env forwarding, watchdog |

## The numbers

| | Before | After (standard) | After (deep) |
|---|---:|---:|---:|
| Competition slides | 89 | ~25 | 89 |
| Campaign slides | 69 | ~25 | 69 |
| Total deck | 343 | ~225 | 343 |
| Silent script failures shown | 0 | all of them | all of them |
| Parquet cache status always printed | no | yes | yes |
| UI survives two instances | crashed | auto-next-port | auto-next-port |
| Peak RAM logged | no | yes | yes |
| Hardcoded Mac paths | 1 | 0 | 0 |

## Critical bugs resolved from #92

- ``executive/05_action_roadmap``: ``[WinError 3] /private/tmp/txn-visual-test`` -- hardcoded Mac dev path fell through on every Windows run.
- ``merchant/08_merchant_volatility``: ``RendererAgg(width=16345162437324666, ...)`` -- matplotlib layout-math overflow from conflicting tight_layout + subplots_adjust + outside-frame suptitle, combined with .str[] on a now-categorical merchant column.
- ``campaign/31,32,33``: memory exhaustion cluster. Memory hygiene (plt.close('all') + gc.collect() between scripts) addresses accumulated matplotlib figure buffers.
- ``attrition_txn/05_monthly_progression``: ``time data 'Total' doesn't match format '%b%y'`` -- aggregate row reached pd.to_datetime.
- ``payroll/05 + 10``: ``.str accessor with string values`` -- numeric branch IDs (branch_config.json missing) fed into .str[].
- **Silent error swallow**: ``22/22 OK'' reports despite 8 real failures. Fixed at the wrapper so all downstream dashboards / Excel reports now reflect actual status.

## New capabilities

**SLIDE_MODE env var** (``standard`` default, ``deep``, ``minimal``) -- Opt-in deck-size control without deleting any code. Each section's 01_*.py reads the env var and sets ``SKIP_SCRIPT_PATTERNS`` on the shared namespace; ``txn_wrapper._execute_scripts`` skips matching scripts with a clear log line. Patterns reset between sections so scoping is per-section.

**SLIDE_BUDGET env var** (default 150) -- After the TXN summary, if total slides exceed budget, print a notice with the 5 heaviest sections and suggest switching SLIDE_MODE.

**Memory telemetry** -- Records process RSS after ``txn_setup`` finishes. Helps diagnose whether campaign memory crashes are a setup problem or a downstream leak.

**Branch config client-aware lookup** -- Searches ``M:\ARS\03_Config\branch_configs\{CLIENT_ID}.json`` first, then shared, then CWD-relative. Visible boxed warning when missing (was a quiet two-line message before).

**UI auto-port** -- When 8000 is in use, walks up to 8010 instead of hard-erroring. PID + URL + active SLIDE_MODE printed in startup banner so two instances can be told apart.

## Files changed

13 files, +505 / -73 lines. No files deleted.

## Testing plan

This branch has NOT been run against a live client yet -- I don't have M: drive access from the Mac. Suggested verification on the work machine:

- [ ] Pull ``fix/txn-pipeline-hardening-20260424`` and ``pip install -r requirements.txt``
- [ ] Run one client end-to-end (UI or ``01_Analysis/run.py --month ... --csm ... --client ...``)
- [ ] Verify the Parquet cache status block prints (HIT/MISS/NO CACHE)
- [ ] Verify the TXN summary prints per-script failures if any occur
- [ ] Verify the final deck has ~225 slides (vs 343 before)
- [ ] Confirm the competition section still has the core 07-09/15-16/31-33 slides
- [ ] Try ``SLIDE_MODE=deep python run.py ...`` and verify full 89 + 69 sections come back
- [ ] Try ``SLIDE_MODE=minimal`` and verify ~10-slide sections
- [ ] Open ``app.py`` on a machine that already has another instance on 8000 and verify it picks port 8001

If any step fails, revert this branch from main (``git revert <merge-sha>``) and file a follow-up issue.