### PR TITLE
fix(txn): inject eligible filter into TXN namespace (denominator framework)

### DIFF
--- a/01_Analysis/00-Scripts/analytics/campaign/04_campaign_penetration.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/04_campaign_penetration.py
@@ -16,7 +16,9 @@ else:
     _acct_col = rewards_df['Acct Number' if 'Acct Number' in rewards_df.columns
                            else ' Acct Number'].astype(str).str.strip()
 
-    # Total population = all accounts in ODDD (the full portfolio)
+    # Total population = eligible accounts in rewards_df (filtered upstream
+    # by txn_wrapper._inject_eligible_filter; falls back to full ODDD if
+    # ELIGIBLE_FILTER_APPLIED is False).
     total_population = len(_acct_col.unique())
 
     cum_mailed_set = set()
@@ -156,7 +158,8 @@ else:
                   color=GEN_COLORS['accent'], linewidth=3,
                   marker='D', markersize=8, zorder=5,
                   label='Response Penetration (% of portfolio)')
-    ax1_twin.set_ylabel(f"% of Total Portfolio ({total_population:,} accounts)", fontsize=16,
+    _pen_base_label = "Eligible Portfolio" if globals().get('ELIGIBLE_FILTER_APPLIED') else "Total Portfolio"
+    ax1_twin.set_ylabel(f"% of {_pen_base_label} ({total_population:,} accounts)", fontsize=16,
                          fontweight='bold', color=GEN_COLORS['accent'], labelpad=10)
     ax1_twin.yaxis.set_major_formatter(plt.FuncFormatter(gen_fmt_pct))
     ax1_twin.spines['top'].set_visible(False)
@@ -228,10 +231,11 @@ else:
     # Value labels with percentages (all vs total portfolio)
     for j, val in enumerate(funnel_values):
         pct = val / total_population * 100 if total_population > 0 else 0
+        _pen_pct_base = "eligible" if globals().get('ELIGIBLE_FILTER_APPLIED') else "portfolio"
         if j == 0:
             pct_label = f"  {val:,}"
         else:
-            pct_label = f"  {val:,}  ({pct:.1f}% of portfolio)"
+            pct_label = f"  {val:,}  ({pct:.1f}% of {_pen_pct_base})"
         ax2.text(val, j, pct_label, va='center', fontsize=14,
                  fontweight='bold', color=funnel_colors[j])
 
@@ -288,7 +292,7 @@ else:
                 ('padding-bottom', '12px'),
             ]},
         ])
-        .set_caption(f"Campaign Penetration by Period  (Total portfolio: {total_population:,} accounts  |  {DATASET_LABEL})")
+        .set_caption(f"Campaign Penetration by Period  ({'Eligible' if globals().get('ELIGIBLE_FILTER_APPLIED') else 'Total'} portfolio: {total_population:,} accounts  |  {DATASET_LABEL})")
         .bar(subset=['Resp Pen %'], color=GEN_COLORS['success'], vmin=0)
     )
 
@@ -297,11 +301,12 @@ else:
     # -----------------------------------------------------------------
     # 4. Console summary
     # -----------------------------------------------------------------
-    print(f"\n    Penetration Analysis (vs total portfolio of {total_population:,} accounts):")
+    _pen_console_base = "eligible portfolio" if globals().get('ELIGIBLE_FILTER_APPLIED') else "total portfolio"
+    print(f"\n    Penetration Analysis (vs {_pen_console_base} of {total_population:,} accounts):")
     print(f"    Total unique mailed: {total_unique_mailed:,} "
-          f"({repeat_summary['mail_penetration_pct']:.1f}% of portfolio)")
+          f"({repeat_summary['mail_penetration_pct']:.1f}% of {_pen_console_base})")
     print(f"    Total unique responded (ever): {total_unique_responded:,} "
-          f"({repeat_summary['resp_penetration_pct']:.1f}% of portfolio)")
+          f"({repeat_summary['resp_penetration_pct']:.1f}% of {_pen_console_base})")
     print(f"    Cumulative response rate (of mailed): {repeat_summary['response_rate_pct']:.1f}%")
     if total_unique_responded > 0:
         print(f"    Single-response accounts: {single_responders:,} "

--- a/01_Analysis/00-Scripts/analytics/txn_wrapper.py
+++ b/01_Analysis/00-Scripts/analytics/txn_wrapper.py
@@ -378,6 +378,89 @@ def _optimize_combined_df(namespace: dict[str, Any]) -> None:
     )
 
 
+def _inject_eligible_filter(namespace: dict[str, Any], ctx: PipelineContext) -> None:
+    """Filter combined_df and rewards_df to eligible accounts only.
+
+    Why: TXN scripts compute rates against the raw TXN universe, producing
+    KPI cards labeled "Eligible Accounts" whose underlying base does not
+    match the ARS-side eligible denominator. This injection enforces the
+    4-denominator framework (Eligible / Eligible Personal / Eligible
+    Business / Open) defined in pipeline/steps/subsets.py.
+
+    Exposes:
+        ELIGIBLE_ACCOUNTS         set[str]      -- canonical eligible account IDs
+        ELIGIBLE_FILTER_APPLIED   bool          -- True iff filtering happened
+        combined_df               filtered      -- replaces unfiltered version
+        rewards_df                filtered      -- replaces unfiltered version
+        combined_df_all           original      -- pre-filter, escape hatch
+        rewards_df_all            original      -- pre-filter, escape hatch
+
+    No-ops (logs warning) if ctx.subsets.eligible_data is unavailable, so
+    legacy clients without proper eligible config don't break the pipeline.
+    """
+    if ctx.subsets is None or ctx.subsets.eligible_data is None:
+        logger.warning(
+            "Eligible filter NOT applied -- ctx.subsets.eligible_data is unavailable. "
+            "TXN denominators will use unfiltered combined_df. Check client EligibleStatusCodes config."
+        )
+        namespace["ELIGIBLE_ACCOUNTS"] = set()
+        namespace["ELIGIBLE_FILTER_APPLIED"] = False
+        return
+
+    elig_df = ctx.subsets.eligible_data
+
+    acct_col = None
+    for candidate in ("Acct Number", " Acct Number", "Account Number", "AcctNumber"):
+        if candidate in elig_df.columns:
+            acct_col = candidate
+            break
+    if acct_col is None:
+        logger.warning(
+            "Eligible filter NOT applied -- no recognized account column in eligible_data. "
+            "Columns: {cols}",
+            cols=list(elig_df.columns)[:15],
+        )
+        namespace["ELIGIBLE_ACCOUNTS"] = set()
+        namespace["ELIGIBLE_FILTER_APPLIED"] = False
+        return
+
+    eligible_set = set(elig_df[acct_col].astype(str).str.strip())
+    namespace["ELIGIBLE_ACCOUNTS"] = eligible_set
+    namespace["ELIGIBLE_FILTER_APPLIED"] = True
+
+    combined = namespace.get("combined_df")
+    if combined is not None and hasattr(combined, "columns") and "primary_account_num" in combined.columns:
+        namespace["combined_df_all"] = combined
+        before = len(combined)
+        mask = combined["primary_account_num"].astype(str).str.strip().isin(eligible_set)
+        namespace["combined_df"] = combined[mask]
+        after = len(namespace["combined_df"])
+        logger.info(
+            "combined_df filtered to eligible: {before:,} -> {after:,} rows ({pct:.1f}% retained)",
+            before=before, after=after,
+            pct=(after / before * 100) if before > 0 else 0,
+        )
+
+    rewards = namespace.get("rewards_df")
+    if rewards is not None and hasattr(rewards, "columns"):
+        rewards_acct_col = None
+        for candidate in ("Acct Number", " Acct Number", "Account Number"):
+            if candidate in rewards.columns:
+                rewards_acct_col = candidate
+                break
+        if rewards_acct_col is not None:
+            namespace["rewards_df_all"] = rewards
+            before = len(rewards)
+            mask = rewards[rewards_acct_col].astype(str).str.strip().isin(eligible_set)
+            namespace["rewards_df"] = rewards[mask]
+            after = len(namespace["rewards_df"])
+            logger.info(
+                "rewards_df filtered to eligible: {before:,} -> {after:,} rows ({pct:.1f}% retained)",
+                before=before, after=after,
+                pct=(after / before * 100) if before > 0 else 0,
+            )
+
+
 def prepare_shared_namespace(ctx: PipelineContext) -> dict[str, Any]:
     """Build namespace and run txn_setup ONCE for all sections.
 
@@ -385,6 +468,10 @@ def prepare_shared_namespace(ctx: PipelineContext) -> dict[str, Any]:
     (millions of rows x up to 12 months), concatenates them into combined_df,
     loads the ODD file, and merges. Previously this ran 22 times (once per
     section). Now it runs once and the namespace is shared.
+
+    After txn_setup builds combined_df + rewards_df, the eligible filter is
+    applied so all downstream TXN scripts compute rates against the correct
+    denominator (see _inject_eligible_filter).
 
     Returns:
         Fully initialized namespace with combined_df, rewards_df, helper
@@ -405,6 +492,9 @@ def prepare_shared_namespace(ctx: PipelineContext) -> dict[str, Any]:
 
     # Optimize memory after the heavy data loading
     _optimize_combined_df(namespace)
+
+    # Apply 4-denominator framework to TXN data (Audit 2026-04-27 Entry 1)
+    _inject_eligible_filter(namespace, ctx)
 
     elapsed = time.time() - t0
     row_count = 0


### PR DESCRIPTION
## Summary

TXN scripts compute rates against raw \`combined_df\` / \`rewards_df\` instead of \`ctx.subsets.eligible_data\`, producing KPI cards labeled \"Eligible Accounts\" whose underlying base does not match the ARS-side eligible denominator built in \`pipeline/steps/subsets.py\`. This is a labeling defect on client-facing slides — a client comparing the ARS \"Eligible\" count to the Campaign \"Eligible Accounts\" card sees two different numbers under the same label.

Fixed by adding \`_inject_eligible_filter()\` in \`txn_wrapper.prepare_shared_namespace()\` that runs after \`txn_setup\`. It:
- Extracts eligible account IDs from \`ctx.subsets.eligible_data\`
- Filters \`combined_df\` and \`rewards_df\` to eligible accounts only
- Exposes \`ELIGIBLE_ACCOUNTS\` (set) and \`ELIGIBLE_FILTER_APPLIED\` (bool) for any script that wants to reason about the filter
- Preserves originals as \`combined_df_all\` / \`rewards_df_all\` (escape hatch)
- Logs before/after row counts for audit trail
- No-ops with a WARNING if \`eligible_data\` is unavailable (legacy clients with missing config don't break)

Also updates \`campaign/04_campaign_penetration.py\` so labels say \"Eligible portfolio\" instead of \"Total portfolio\" when the filter is active (chart ylabel, funnel labels, table caption, console output).

## Why now

Surfaced by an audit on 2026-04-27 (see \`Analysis Audit 4-27.md\` Entry 1, on the \`feature/client-deck-3-stories\` branch). The denominator framework defined in \`pipeline/steps/subsets.py\` is correctly built and consumed by ARS-side modules, but the ~330 TXN scripts bypass it. This blocks the planned 3-story client deck (\`docs/deck/CLIENT_DECK_PLAN.md\`) since hero slides span ARS + TXN modules and need consistent denominators.

## Conflicts with PR #93

PR #93 modifies \`txn_wrapper.py\` (+142 -17) for unrelated work (silent failure surfacing, memory hygiene, SLIDE_MODE env var). **There will be a merge conflict.** Resolution path:
- If #93 merges first, I rebase this PR onto main.
- If this PR merges first, #93 rebases.
- Either way the changes are conceptually independent (different functions in the same file).

## Test plan

- [ ] Run pipeline on a known client (where prior decks exist).
- [ ] Confirm logs show \`combined_df filtered to eligible: X -> Y rows\` and \`rewards_df filtered to eligible: X -> Y rows\`.
- [ ] Confirm Campaign KPI \"Eligible Accounts\" card now matches ARS-side eligible count.
- [ ] Spot-check 2-3 TXN slides for sane numbers.
- [ ] Confirm no TXN section script crashes on a client missing eligible config (filter no-ops gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)