### PR TITLE
fix(odd+txn): accept extensionless _transaction files and ODD files outside client subfolder

### DIFF
--- a/00_Formatting/run.py
+++ b/00_Formatting/run.py
@@ -226,12 +226,17 @@ def gather_trans_files(src_directory, txn_output_base, csm_name, client_filter=N
     #   1562_..._velocity.ars.transactions.YYYY.MM.DD.txt
     #   1585_..._monthly_transaction_data_mls.txt
     #   1795_..._monthlytran.csv
+    #   1745_29335_[YYYY.MM.DD][HH.MM.SS]_transaction  (no extension)
     trans_files = []
     for f in os.listdir(src_directory):
         if os.path.isdir(os.path.join(src_directory, f)):
             continue
         f_lower = f.lower()
-        if 'tran' in f_lower and f_lower.endswith(('.txt', '.csv')):
+        is_txn = (
+            ('tran' in f_lower and f_lower.endswith(('.txt', '.csv')))
+            or f_lower.endswith('_transaction')
+        )
+        if is_txn:
             # Extract client ID: either leading digits before _ or before -
             client_match = re.match(r'^(\d+)', f)
             if client_match:

--- a/01_Analysis/00-Scripts/analytics/txn_setup/02-file-config.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/02-file-config.py
@@ -119,6 +119,20 @@ def parse_file_date(filepath: Path) -> datetime | None:
     return None
 
 
+def _is_txn_file(p: Path) -> bool:
+    """A TXN file is .txt/.csv, or extensionless ending in `_transaction`.
+
+    The latter covers Dan's `1745_29335_[YYYY.MM.DD][HH.MM.SS]_transaction`
+    files, which have no extension (Path.suffix picks up the trailing
+    `.26]_transaction` from the bracketed timestamp, not a real suffix).
+    """
+    if not p.is_file():
+        return False
+    if p.suffix.lower() in ('.txt', '.csv'):
+        return True
+    return p.name.lower().endswith('_transaction')
+
+
 def gather_all_txn_files(client_root: Path) -> list[Path]:
     """Gather all TXN files from client folder.
 
@@ -132,12 +146,12 @@ def gather_all_txn_files(client_root: Path) -> list[Path]:
     all_files: list[Path] = []
 
     for item in client_root.iterdir():
-        if item.is_file() and item.suffix.lower() in ('.txt', '.csv'):
+        if _is_txn_file(item):
             all_files.append(item)
         elif item.is_dir() and item.name.isdigit() and len(item.name) == 4:
             # Year folder
             for f in item.iterdir():
-                if f.is_file() and f.suffix.lower() in ('.txt', '.csv'):
+                if _is_txn_file(f):
                     all_files.append(f)
 
     return all_files

--- a/01_Analysis/run.py
+++ b/01_Analysis/run.py
@@ -85,22 +85,48 @@ def _resolve_csm_name(csm_input, base_path):
 
 
 def _find_odd_file(csm, month, client_id):
-    """Auto-find the formatted ODD file from the standard path structure."""
+    """Auto-find the formatted ODD file regardless of how it landed.
+
+    Tries each candidate CSM folder (exact match first, then fuzzy
+    `startswith`):
+
+      1. `{CSM}/{month}/{client_id}/*.xlsx`           -- canonical
+      2. `{CSM}/{month}/{client_id}-*-ODD.xlsx`       -- file at month level
+      3. `{CSM}/{month}/{client_id}*.xlsx`            -- any xlsx prefixed by
+                                                         client_id at month level
+    """
     if os.name == "nt":
         base = Path(r"M:\ARS\00_Formatting\02-Data-Ready for Analysis")
     else:
         base = Path("/Volumes/M/ARS/00_Formatting/02-Data-Ready for Analysis")
 
-    # Fuzzy match CSM name
-    csm = _resolve_csm_name(csm, base)
-
-    client_dir = base / csm / month / client_id
-    if not client_dir.exists():
+    if not base.exists():
         return None
 
-    xlsx_files = list(client_dir.glob("*.xlsx"))
-    if xlsx_files:
-        return xlsx_files[0]
+    csm_dirs: list[Path] = []
+    exact = base / csm
+    if exact.is_dir():
+        csm_dirs.append(exact)
+    for d in base.iterdir():
+        if d.is_dir() and d.name.lower().startswith(csm.lower()) and d not in csm_dirs:
+            csm_dirs.append(d)
+
+    for csm_dir in csm_dirs:
+        month_dir = csm_dir / month
+        if not month_dir.is_dir():
+            continue
+
+        client_dir = month_dir / client_id
+        if client_dir.is_dir():
+            xlsx_files = sorted(client_dir.glob("*.xlsx"))
+            if xlsx_files:
+                return xlsx_files[0]
+
+        for pattern in (f"{client_id}-*-ODD.xlsx", f"{client_id}-*.xlsx", f"{client_id}*.xlsx"):
+            matches = sorted(f for f in month_dir.glob(pattern) if f.is_file())
+            if matches:
+                return matches[0]
+
     return None
 
 

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -80,18 +80,47 @@ def get_csm_list():
 
 
 def find_formatted_odd(csm, month, client_id):
-    """Find the formatted ODD file for a client."""
-    client_dir = READY_FOR_ANALYSIS / csm / month / client_id
-    if not client_dir.exists():
-        if READY_FOR_ANALYSIS.exists():
-            for d in READY_FOR_ANALYSIS.iterdir():
-                if d.is_dir() and d.name.lower().startswith(csm.lower()):
-                    client_dir = d / month / client_id
-                    break
-    if not client_dir.exists():
+    """Find the formatted ODD file for a client.
+
+    Looks for an ODD file regardless of how it got into 02-Data-Ready for
+    Analysis (UI, CLI, manual placement). Tries each candidate CSM folder
+    (exact match first, then fuzzy `startswith`):
+
+      1. `{CSM}/{month}/{client_id}/*.xlsx`           -- canonical
+      2. `{CSM}/{month}/{client_id}-*-ODD.xlsx`       -- file at month level
+      3. `{CSM}/{month}/{client_id}*.xlsx`            -- any xlsx prefixed by
+                                                         client_id at month level
+
+    Returns the first match as a string, or None.
+    """
+    if not READY_FOR_ANALYSIS.exists():
         return None
-    xlsx = list(client_dir.glob("*.xlsx"))
-    return str(xlsx[0]) if xlsx else None
+
+    csm_dirs: list[Path] = []
+    exact = READY_FOR_ANALYSIS / csm
+    if exact.is_dir():
+        csm_dirs.append(exact)
+    for d in READY_FOR_ANALYSIS.iterdir():
+        if d.is_dir() and d.name.lower().startswith(csm.lower()) and d not in csm_dirs:
+            csm_dirs.append(d)
+
+    for csm_dir in csm_dirs:
+        month_dir = csm_dir / month
+        if not month_dir.is_dir():
+            continue
+
+        client_dir = month_dir / client_id
+        if client_dir.is_dir():
+            xlsx = sorted(client_dir.glob("*.xlsx"))
+            if xlsx:
+                return str(xlsx[0])
+
+        for pattern in (f"{client_id}-*-ODD.xlsx", f"{client_id}-*.xlsx", f"{client_id}*.xlsx"):
+            matches = sorted(f for f in month_dir.glob(pattern) if f.is_file())
+            if matches:
+                return str(matches[0])
+
+    return None
 
 
 def get_recent_runs():


### PR DESCRIPTION
## Summary

Two fixes verified working on Dan / 1745 / 2026.05 (run completed 4/4 steps, 158 slides, 21.4 MB deck — see [1745_20260511_162436.log](https://github.com/JG-CSI-Velocity/ars-production-pipeline/issues/100)).

| Commit | Fix |
|---|---|
| `9509ea1` | Accept extensionless `_transaction` files in `gather_trans_files` (formatting) and `gather_all_txn_files` (analysis). Dan's TXN files arrive named `1745_29335_[2025.06.06][08.19.26]_transaction` with no extension; the previous `endswith(('.txt', '.csv'))` filter silently dropped them. |
| `9df9e8b` | `find_formatted_odd()` (`05_UI/app.py`) and `_find_odd_file()` (`01_Analysis/run.py`) now look in `{CSM}/{month}/{client_id}/*.xlsx` (canonical), then `{CSM}/{month}/{client_id}-*-ODD.xlsx` (month-level), then broader fallbacks. Also fuzzy CSM folder match (`dan` ↔ `Dan`). |

Closes #100.

## Test plan
- [x] Dan / 1745 / 2026.05 — full pipeline run, 4/4 steps OK, 158 slides
- [x] TXN files load — 12 `_transaction` files picked up
- [x] ODD found regardless of placement (canonical client subfolder or month-level)

## Why this needs to land

The branch is 2 commits ahead of main with no PR. Other team members pulling `main` don't have these fixes. Without the merge, any future client with extensionless TXN files or a manually-placed ODD will hit the same "no formatted ODD" / "no transaction files" failure.