### PR TITLE
fix(financial_services): word-boundary match + normalize card descriptors

### DIFF
--- a/01_Analysis/00-Scripts/analytics/financial_services/02_identify.py
+++ b/01_Analysis/00-Scripts/analytics/financial_services/02_identify.py
@@ -18,23 +18,69 @@ false_positive_patterns = [
 _REGEX_BATCH_SIZE = 80  # avoid massive regex alternations
 
 # ---------------------------------------------------------------------------
+# Card-descriptor normalization
+# ---------------------------------------------------------------------------
+# Same root issue as competition tagging: pattern lists hold full merchant
+# names (TURBOTAX, STATE FARM, CHARLES SCHWAB) but card data arrives as
+# 'INTUIT*TURBOTAX FEES', 'POS DEBIT STATE FARM INS', 'SCHWAB BROKERAGE & CO'
+# with prefixes and middle-of-string brand tokens. Anchored ^ str.match
+# misses all of those. Strip common prefixes, then match with \b word
+# boundaries via str.contains.
+
+import re as _re
+
+_FS_CARD_PREFIX_RE = _re.compile(
+    r'^(?:'
+    r'POS\s+(?:DEBIT|PURCH(?:ASE)?|WITHDRAWAL|CREDIT)|'
+    r'DEBIT\s+(?:CARD\s+(?:PURCHASE|PAYMENT)?|PURCHASE|PMT)|'
+    r'CHECKCARD(?:\s+\d+)?|'
+    r'PURCHASE\s+AUTHORIZED(?:\s+ON\s+\d+/\d+)?|'
+    r'RECURRING\s+(?:DEBIT\s+)?PMT|'
+    r'WEB\s+AUTH(?:ORIZED)?\s+PMT|'
+    r'EXTERNAL\s+WITHDRAWAL|'
+    r'ACH\s+(?:DEBIT|WITHDRAWAL|DEPOSIT|TRANSFER|PMT)|'
+    r'SQ\s*\*|TST\s*\*|PP\s*\*|SP\s*\*|PY\s*\*|EZP\s*\*|'
+    r'INTUIT\s*\*|INTUIT\s+'    # 'INTUIT*TURBOTAX', 'INTUIT TURBOTAX'
+    r')\s*',
+    _re.IGNORECASE,
+)
+
+
+def _fs_normalize(s):
+    """Strip card-network prefixes + punctuation, collapse whitespace.
+
+    Drops punctuation so `H&R BLOCK` pattern matches `H R BLOCK ONLINE`
+    in data (and vice versa), and `H.R. BLOCK` lines up too.
+    """
+    s = str(s).upper().strip()
+    s = _FS_CARD_PREFIX_RE.sub('', s)
+    s = _re.sub(r'[^\w\s]', ' ', s)
+    return _re.sub(r'\s+', ' ', s).strip()
+
+
+# ---------------------------------------------------------------------------
 # PERFORMANCE: Match patterns against unique merchants first, then filter.
 # This avoids running regex against millions of rows for every category.
 # ---------------------------------------------------------------------------
 _unique_merchants = combined_df[search_column].dropna().unique()
 _unique_merch_series = pd.Series(_unique_merchants)
+# Normalized form for matching, but keep the originals to filter back into
+# combined_df (isin() needs the originals).
+_unique_norm_series = _unique_merch_series.map(_fs_normalize)
 
 for category, patterns in FINANCIAL_SERVICES_PATTERNS.items():
-    # Match patterns against unique merchant names (much smaller list)
-    # Uses prefix matching (str.match with ^) to be consistent with
-    # section 06's tag_competitors() which also uses starts_with logic.
-    import re as _re
-    _merch_mask = pd.Series(False, index=_unique_merch_series.index)
-    for _i in range(0, len(patterns), _REGEX_BATCH_SIZE):
-        _batch = patterns[_i:_i + _REGEX_BATCH_SIZE]
-        _regex = '^(?:' + '|'.join(_re.escape(p) for p in _batch) + ')'
-        _merch_mask |= _unique_merch_series.str.match(
-            _regex, case=False, na=False
+    # Match patterns against unique merchant names (much smaller list).
+    # Word-boundary contains (was anchored ^ str.match): catches
+    # mid-string brand names like 'INTUIT*TURBOTAX' or 'SCHWAB BROKERAGE'.
+    _merch_mask = pd.Series(False, index=_unique_norm_series.index)
+    # Normalize patterns the same way data is normalized.
+    _norm_patterns = [_fs_normalize(p) for p in patterns if p.strip()]
+    _norm_patterns = sorted({p for p in _norm_patterns if p}, key=len, reverse=True)
+    for _i in range(0, len(_norm_patterns), _REGEX_BATCH_SIZE):
+        _batch = _norm_patterns[_i:_i + _REGEX_BATCH_SIZE]
+        _regex = r'\b(?:' + '|'.join(_re.escape(p) for p in _batch) + r')\b'
+        _merch_mask |= _unique_norm_series.str.contains(
+            _regex, case=False, na=False, regex=True
         )
     _matched_merchants = set(_unique_merch_series[_merch_mask].values)
 


### PR DESCRIPTION
## The problem

1200's financial services counts are severely under-counted:
- 21 auto loan accounts
- 132 investment/brokerage accounts
- 52 financial advisory
- 21 personal loans
- 157 crypto

vs. 4100 wallets and 1700 BNPL (which look right). In a 36K Florida CU portfolio with retirees, those low numbers are not real — they're detection failures.

## Root cause

Same architectural bug that affected competition (#102). `02_identify.py` matches financial-services patterns with `^(?:PATTERN1|PATTERN2|…)` anchored at the **start** of the merchant string. Card-network descriptors arrive as:

| Pattern | Data (misses) |
| --- | --- |
| `TURBOTAX` | `INTUIT *TURBOTAX FEES` |
| `CHARLES SCHWAB` | `SCHWAB BROKERAGE & CO` |
| `VANGUARD GROUP` | `PURCHASE AUTHORIZED ON 05/12 VANGUARD GROUP` |
| `EDWARD JONES` | `SQ *EDWARD JONES INV` |
| `TOYOTA FINANCIAL` | `POS DEBIT TOYOTA FINANCIAL PHX AZ` |
| `UPSTART NETWORK` | `WEB AUTH PMT UPSTART NETWORK` |
| `H&R BLOCK` | `H R BLOCK ONLINE FILING` |

Wallets / BNPL detection works because Apple Pay / Venmo / Affirm come in as clean prefix-free strings.

## The fix

- `_fs_normalize()` strips card-network descriptor prefixes (`POS DEBIT`, `CHECKCARD`, `PURCHASE AUTHORIZED ON`, `SQ *`, `INTUIT *`, `WEB AUTH PMT`, `ACH …`, etc.), drops punctuation (`H&R BLOCK` ↔ `H R BLOCK`), and collapses whitespace.
- Both patterns and the unique-merchant Series get normalized identically.
- Matching changed from `^…` start-anchor `str.match` to `\b…\b` word-boundary `str.contains` — brand names can appear at start/middle/end.
- Performance: still operates on `_unique_merchants` (small list), still filters back into `combined_df` via `isin()` on the original strings.

## Test plan
- [x] Smoke test with 19 realistic card descriptors:
  - 14 correctly tagged into the right categories (Auto, Brokerage, Tax, Advisory, Insurance, Crypto, Personal Loans)
  - `CASH APP RANDOM USER` and `AMAZON.COM` correctly stay untagged
  - 1 missed only because of a missing pattern variant (`SCHWAB BROKERAGE` not in config — data fix, not code)
- [ ] Run 1200 / 2026.05 on the work box and verify category counts jump to realistic numbers

## Files changed
- `01_Analysis/00-Scripts/analytics/financial_services/02_identify.py`

## Companion to #102

Identical normalization strategy as PR #102 (competition). If you wanted, the helpers could later be moved to a shared `txn_setup` module so both sections call the same function. For now, intentionally self-contained per section to keep blast radius small.