### PR TITLE
fix(charts): add chart_title helper + fix cramped 34/36 spacing

### DIFF
--- a/01_Analysis/00-Scripts/analytics/campaign/34_responder_account_age_chart.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/34_responder_account_age_chart.py
@@ -179,11 +179,12 @@ else:
                      color=_DARK, transform=ax3.transAxes, va='top', ha='right')
             _y -= 0.10
 
-    # Main title
-    fig.suptitle('Account Age & Campaign Response',
-                 fontsize=22, fontweight='bold', color=_DARK, y=0.96)
-    fig.text(0.5, 0.915,
-             'How long has the account been open?  |  Accounts < 90 days excluded  |  All mailers pooled',
-             ha='center', fontsize=14, color=_MUTED, style='italic')
+    # Main title (uses chart_title helper for consistent spacing)
+    chart_title(
+        fig,
+        'Account Age & Campaign Response',
+        subtitle='How long has the account been open?  |  Accounts < 90 days excluded  |  All mailers pooled',
+        title_color=_DARK, subtitle_color=_MUTED,
+    )
 
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/campaign/36_responder_holder_age_chart.py
+++ b/01_Analysis/00-Scripts/analytics/campaign/36_responder_holder_age_chart.py
@@ -177,11 +177,12 @@ else:
                      color=_DARK, transform=ax3.transAxes, va='top', ha='right')
             _y -= 0.10
 
-    # Main title
-    fig.suptitle('Account Holder Age & Campaign Response',
-                 fontsize=22, fontweight='bold', color=_DARK, y=0.96)
-    fig.text(0.5, 0.915,
-             'How old is the account holder?  |  All mailers pooled',
-             ha='center', fontsize=14, color=_MUTED, style='italic')
+    # Main title (uses chart_title helper for consistent spacing)
+    chart_title(
+        fig,
+        'Account Holder Age & Campaign Response',
+        subtitle='How old is the account holder?  |  All mailers pooled',
+        title_color=_DARK, subtitle_color=_MUTED,
+    )
 
     plt.show()

--- a/01_Analysis/00-Scripts/analytics/general/01_general_theme.py
+++ b/01_Analysis/00-Scripts/analytics/general/01_general_theme.py
@@ -147,6 +147,39 @@ def gen_fmt_dollar(x, _):
     return f"${x:,.0f}"
 
 # ---------------------------------------------------------------------------
+# Helper: consistent title + subtitle placement
+# ---------------------------------------------------------------------------
+# Universal rule: title sits above the figure (y=1.02), subtitle sits inside
+# the figure at y=0.94 (default) — that yields >=0.08 figure-height clearance
+# between them at any normal figsize. Caller can override if needed, but
+# the defaults should be safe everywhere.
+def chart_title(fig, title, subtitle=None, title_size=22, subtitle_size=14,
+                title_y=1.02, subtitle_y=0.94, reserve_top=0.88,
+                title_color=None, subtitle_color=None):
+    """Place a title (and optional subtitle) with consistent spacing.
+
+    Use this in new code instead of bare ``fig.suptitle`` + ``fig.text``
+    so subtitles never end up jammed against the title.
+    """
+    if title_color is None:
+        title_color = GEN_COLORS['dark_text']
+    if subtitle_color is None:
+        subtitle_color = GEN_COLORS['muted']
+
+    fig.suptitle(title, fontsize=title_size, fontweight='bold',
+                 color=title_color, y=title_y)
+    if subtitle:
+        fig.text(0.5, subtitle_y, subtitle, ha='center',
+                 fontsize=subtitle_size, color=subtitle_color, style='italic')
+        # When a subtitle is present, reserve more space at the top so
+        # the axes don't crowd it.
+        try:
+            fig.subplots_adjust(top=reserve_top)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
 # Helper: remove chart clutter
 # ---------------------------------------------------------------------------
 def gen_clean_axes(ax, keep_left=True, keep_bottom=True):


### PR DESCRIPTION
- Adds `chart_title(fig, title, subtitle, ...)` to `general/01_general_theme.py` (places title at y=1.02 above frame, subtitle at y=0.94 inside frame, calls `subplots_adjust(top=0.88)`). Guarantees >=0.08 figure-height clearance.
- Applies it to `campaign/34_responder_account_age_chart.py` and `campaign/36_responder_holder_age_chart.py` (the two charts with the literal `y=0.96 + 0.915` cramped pattern).
- Follow-up: I'll sweep the remaining ~115 chart files in a separate PR.