### PR TITLE
fix(detection+branches): aggregation, NEIMAN MARCUS FP, ARS branch-name regression

### DIFF
--- a/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
+++ b/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
@@ -98,7 +98,8 @@ UNIVERSAL_COMPETITORS = {
             'CURRENT MOBILE', 'CURRENT BANK', 'CURRENT FINANCIAL',
             'ALLY', 'ALLY BANK', 'ALLY FINANCIAL',
             'DISCOVER BANK', 'DISCOVER SAVINGS', 'DISCOVER CARD', 'DISCOVER',
-            'MARCUS', 'MARCUS BY GOLDMAN', 'MARCUS BANK', 'MARCUS PMT', 'MARCUS GOLDMAN',
+            # NOTE: do NOT add 'MARCUS' bare — it false-positives on NEIMAN MARCUS.
+            'MARCUS BY GOLDMAN', 'MARCUS BANK', 'MARCUS PMT', 'MARCUS GOLDMAN',
             'REVOLUT',
             'MONZO',
             'N26',
@@ -871,6 +872,12 @@ def tag_competitors(df, merchant_col='merchant_consolidated'):
         'CHURCH', 'MINISTRY',
         'SCHOOL', 'ACADEMY', 'UNIVERSITY',
         'TRADER JOE',
+        # Brand-name collisions with universal patterns
+        'NEIMAN MARCUS', 'NEIMAN',          # vs digital_banks MARCUS (Goldman)
+        'MARCUS THEATRES', 'MARCUS THEATR', # cinema chain
+        'DISCOVERY',                        # vs digital_banks DISCOVER
+        'CITRUS',                           # vs big_nationals CITI
+        'CHASE FIELD', 'CHASE STADIUM',     # baseball venue, not CHASE bank
     ]
     # Use word boundaries so 'SPA' doesn't match 'SPACE', 'CAFE' doesn't
     # match anything inside another word, etc.

--- a/01_Analysis/00-Scripts/analytics/competition/61_banks_only_donut.py
+++ b/01_Analysis/00-Scripts/analytics/competition/61_banks_only_donut.py
@@ -172,8 +172,8 @@ else:
 
         fig.suptitle("Category Breakdown — Banks Only",
                      fontsize=28, fontweight='bold',
-                     color=GEN_COLORS['dark_text'], y=1.02)
-        fig.text(0.5, 0.965,
+                     color=GEN_COLORS['dark_text'], y=1.00)
+        fig.text(0.5, 0.92,
                  f"Excludes wallets / P2P / BNPL ({_eco_txns:,} txns, {_eco_pct:.1f}% of competitor activity)",
                  ha='center', fontsize=14, color=GEN_COLORS['muted'], style='italic')
 

--- a/01_Analysis/00-Scripts/analytics/competition/61_core_competition_donut.py
+++ b/01_Analysis/00-Scripts/analytics/competition/61_core_competition_donut.py
@@ -90,8 +90,8 @@ else:
 
     fig.suptitle("Category Breakdown — Banks + BNPL (Ex Wallets + P2P)",
                  fontsize=26, fontweight='bold',
-                 color=GEN_COLORS['dark_text'], y=1.02)
-    fig.text(0.5, 0.965, SCOPE_NOTE,
+                 color=GEN_COLORS['dark_text'], y=1.00)
+    fig.text(0.5, 0.92, SCOPE_NOTE,
              ha='center', fontsize=13, color=GEN_COLORS['muted'], style='italic')
 
     plt.tight_layout()

--- a/01_Analysis/00-Scripts/analytics/dctr/_helpers.py
+++ b/01_Analysis/00-Scripts/analytics/dctr/_helpers.py
@@ -339,7 +339,12 @@ def branch_dctr(
     dc["Branch"] = dc["Branch"].astype(str)
     if branch_mapping:
         str_mapping = {str(k): v for k, v in branch_mapping.items()}
+        # Float-as-string fallback so "1.0" hits mapping key "1".
         mapped = dc["Branch"].map(str_mapping)
+        unmapped_mask = mapped.isna()
+        if unmapped_mask.any():
+            stripped = dc.loc[unmapped_mask, "Branch"].str.split('.').str[0]
+            mapped.loc[unmapped_mask] = stripped.map(str_mapping)
         dc["Branch Name"] = mapped.where(mapped.notna(), dc["Branch"])
     else:
         dc["Branch Name"] = dc["Branch"]

--- a/01_Analysis/00-Scripts/analytics/rege/branches.py
+++ b/01_Analysis/00-Scripts/analytics/rege/branches.py
@@ -52,13 +52,27 @@ def _branch_rates(
     if df is None or df.empty or "Branch" not in df.columns:
         return pd.DataFrame()
     bm = branch_mapping or {}
+    # Coerce mapping keys to strings so int/str/float branch values can all hit.
+    bm_keyed = {str(k): v for k, v in bm.items()}
+
+    def _resolve(br):
+        s = str(br).strip()
+        if s in bm_keyed:
+            return bm_keyed[s]
+        # Float-as-string fallback: "1.0" -> "1"
+        if '.' in s:
+            stripped = s.split('.')[0]
+            if stripped in bm_keyed:
+                return bm_keyed[stripped]
+        return br
+
     rows = []
     for br in sorted(df["Branch"].dropna().unique()):
         bd = df[df["Branch"] == br]
         t, oi, r = rege(bd, col, opts)
         rows.append(
             {
-                "Branch": bm.get(str(br), br),
+                "Branch": _resolve(br),
                 "Total Accounts": t,
                 "Opted In": oi,
                 "Opted Out": t - oi,

--- a/01_Analysis/00-Scripts/analytics/txn_setup/06-merchant-name-consolidation.py
+++ b/01_Analysis/00-Scripts/analytics/txn_setup/06-merchant-name-consolidation.py
@@ -829,10 +829,131 @@ def standardize_merchant_name(merchant_name):
     
     if 'FORD MOTOR CREDIT' in merchant_upper:
         return 'FORD MOTOR CREDIT'
-    
+
     if 'HONDA FINANCE' in merchant_upper:
         return 'HONDA FINANCE'
-        
+
+    # ============================================================================
+    # GENERIC ADDRESS/LOCATION SUFFIX STRIPPING (fallthrough)
+    # ============================================================================
+    # Many transactions append address/city/state/ZIP/store-number/phone
+    # to the brand name, so ONE merchant appears as many distinct rows in
+    # top-N tables and aggregation breaks. Examples that should collapse:
+    #   'TIAA BANK 121 W MAIN ST JACKSONVILLE FL'  -> 'TIAA BANK'
+    #   'CHASE 4500 BISCAYNE BLVD MIAMI FL 33137'  -> 'CHASE'
+    #   'BANK OF AMERICA #00231 FT LAUDERDALE FL'  -> 'BANK OF AMERICA'
+    # Strategy: trim trailing tokens that look like location/noise data
+    # (state codes, ZIPs, phone numbers, street suffixes, store numbers,
+    # common Florida cities) until a brand-ish token remains.
+    import re as _re
+
+    # Country-agnostic location vocab. No city dictionary -- cities are
+    # detected positionally (one alpha token immediately before a state
+    # code), so this works for clients in any region.
+    _STATE_CODES = {
+        'AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA','HI','ID','IL','IN',
+        'IA','KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT','NE','NV',
+        'NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN',
+        'TX','UT','VT','VA','WA','WV','WI','WY','DC',
+    }
+    _STREET_SUFFIXES = {
+        'ST','STREET','AVE','AVENUE','BLVD','BOULEVARD','RD','ROAD','DR','DRIVE',
+        'LN','LANE','CT','COURT','PL','PLACE','PKWY','PARKWAY','HWY','HIGHWAY',
+        'WAY','TER','TERRACE','CIR','CIRCLE','TRL','TRAIL','SQ','SQUARE',
+        'N','S','E','W','NE','NW','SE','SW',
+        'STE','SUITE','APT','UNIT','BLDG','BUILDING','FLR','FLOOR',
+    }
+    _LOCATION_NOISE = {
+        'BRANCH','BRCH','ATM','LOBBY','DRIVETHRU',
+        'STORE','LOCATION','LOC','POS','SVCS',
+    }
+    # Multi-word city patterns that show up nationwide. Single-word cities
+    # are handled by the positional "1 alpha token before state" rule.
+    _COMPOUND_CITY_TAILS = [
+        ('FT', 'LAUDERDALE'), ('FORT', 'LAUDERDALE'),
+        ('NEW', 'YORK'), ('NEW', 'ORLEANS'), ('NEW', 'HAVEN'),
+        ('LAS', 'VEGAS'), ('LOS', 'ANGELES'),
+        ('SAN', 'FRANCISCO'), ('SAN', 'DIEGO'), ('SAN', 'JOSE'), ('SAN', 'ANTONIO'),
+        ('PALM', 'BEACH'), ('BOCA', 'RATON'), ('BAL', 'HARBOUR'),
+        ('LONG', 'BEACH'), ('LONG', 'ISLAND'),
+        ('KANSAS', 'CITY'), ('OKLAHOMA', 'CITY'), ('SALT', 'LAKE'),
+        ('LITTLE', 'ROCK'), ('SAINT', 'LOUIS'), ('SAINT', 'PAUL'),
+        ('ST', 'LOUIS'), ('ST', 'PAUL'), ('ST', 'PETE'), ('ST', 'PETERSBURG'),
+        ('LAKE', 'WORTH'), ('PEMBROKE', 'PINES'),
+    ]
+
+    def _is_basic_location_token(tok):
+        """Tokens that are ALWAYS location/noise regardless of context."""
+        if not tok:
+            return True
+        if _re.fullmatch(r'\d{5}(-\d{4})?', tok):       # ZIP / ZIP+4
+            return True
+        if _re.fullmatch(r'[\d\-()]{7,}', tok) and \
+                sum(c.isdigit() for c in tok) >= 7:       # phone-ish
+            return True
+        if _re.fullmatch(r'#?\d{1,6}', tok):             # store/street number
+            return True
+        if tok in _STATE_CODES:
+            return True
+        if tok in _STREET_SUFFIXES:
+            return True
+        if tok in _LOCATION_NOISE:
+            return True
+        if len(tok) == 1 and tok.isalpha():              # stray letter
+            return True
+        return False
+
+    _tokens = merchant_upper.split()
+
+    # Pass 1: right-to-left strip of context-free location/noise tokens.
+    # Tracks whether a state code was popped so Pass 2 can do positional
+    # city stripping.
+    _state_popped = False
+    while len(_tokens) > 1 and _is_basic_location_token(_tokens[-1]):
+        if _tokens[-1] in _STATE_CODES:
+            _state_popped = True
+        _tokens.pop()
+
+    # Pass 2: if we stripped a state code, one alpha token immediately
+    # preceding it is almost always the city. Strip ONE such token (and
+    # extend to 2 tokens for the well-known compound patterns above).
+    # This is country-agnostic and doesn't depend on a city list.
+    if _state_popped and len(_tokens) >= 2:
+        _last = _tokens[-1]
+        _prev = _tokens[-2] if len(_tokens) >= 2 else ''
+        # Compound city tail (e.g. FT LAUDERDALE)
+        if (_prev, _last) in _COMPOUND_CITY_TAILS and len(_tokens) > 2:
+            _tokens = _tokens[:-2]
+        # Single-word city: trailing alpha-only token of length >= 3 that
+        # isn't already a brand-suffix keyword.
+        elif (_last.isalpha() and len(_last) >= 3 and
+              _last not in ('BANK','CARD','LOAN','CREDIT','UNION','SAVINGS',
+                            'FINANCIAL','MORTGAGE','TRUST','CAPITAL','GROUP',
+                            'CORP','INC','LLC','CO','SVCS','SERVICES','PMT',
+                            'PAYMENT','MEMBER','FCU','CU','NA','FSB')):
+            _tokens.pop()
+
+    # Pass 3: left-to-right truncate at the first numeric token that looks
+    # like a street/store number. Catches embedded addresses that the
+    # right-side passes can't reach because brand words sit after them
+    # (e.g. 'TIAA BANK 121 W MAIN ST JACKSONVILLE FL' -> 'TIAA BANK').
+    _cut_idx = None
+    for _idx, _tok in enumerate(_tokens):
+        if _idx == 0:
+            continue  # never strip the first token
+        if _re.fullmatch(r'#?\d{1,6}', _tok):       # 121, #4521
+            _cut_idx = _idx
+            break
+        if _re.fullmatch(r'\d{1,5}-\d{1,5}', _tok): # 4500-100
+            _cut_idx = _idx
+            break
+    if _cut_idx is not None:
+        _tokens = _tokens[:_cut_idx]
+
+    _cleaned = ' '.join(_tokens).strip()
+    if _cleaned and _cleaned != merchant_upper:
+        return _cleaned
+
     # ============================================================================
     # If no match, return original
     # ============================================================================


### PR DESCRIPTION
Five user-reported issues in one PR.

## 1. MARCUS / NEIMAN MARCUS false positive
PR #106 added bare `MARCUS` to digital_banks. With word boundaries, `\\bMARCUS\\b` also matches NEIMAN MARCUS (Goldman bank vs Neiman Marcus department store — both have MARCUS as a standalone word). Drop the bare pattern; the multi-word variants (MARCUS BY GOLDMAN, MARCUS BANK, MARCUS LOAN, MARCUS PMT, MARCUS GOLDMAN) still cover real targets. NEIMAN MARCUS / NEIMAN / MARCUS THEATRES / CHASE FIELD / CHASE STADIUM / DISCOVERY / CITRUS added to competition false-positive guard.

## 2. Merchants appearing as addresses (country-agnostic)
One real merchant ends up as many distinct rows in top-N tables because the card descriptor appends address/city/state/ZIP/store-#/phone. Three-pass suffix stripper added to `standardize_merchant_name` fallthrough:

| Pass | What it strips |
|---|---|
| RTL pass | State codes, ZIPs, phone-ish strings, street suffixes (ST/AVE/BLVD/...), directionals (N/S/E/W), store numbers (#1234), single-letter tokens |
| Positional (only if state popped) | ONE preceding alpha token (single-word city) + 2-token compound cities (FT LAUDERDALE, NEW YORK, LAS VEGAS, BOCA RATON, KANSAS CITY, ST LOUIS, PALM BEACH, ...). Brand-suffix keywords (BANK/CARD/LOAN/CREDIT/UNION/SAVINGS/FINANCIAL/MORTGAGE/TRUST/CAPITAL/GROUP/...) are exempt |
| LTR pass | Truncate at first numeric token after the brand (catches `TIAA BANK 121 W MAIN ST...` → `TIAA BANK`) |

**No city dictionary** — works for clients in any state. Verified on FL, AK, CA, NY samples (20/20 collapse correctly):

```
TIAA BANK 121 W MAIN ST JACKSONVILLE FL    -> TIAA BANK
CHASE 4500 BISCAYNE BLVD MIAMI FL 33137    -> CHASE
BANK OF AMERICA #00231 FT LAUDERDALE FL    -> BANK OF AMERICA
NEIMAN MARCUS BAL HARBOUR FL               -> NEIMAN MARCUS
GLOBAL CREDIT UNION 4000 ... ANCHORAGE AK  -> GLOBAL CREDIT UNION
WELLS FARGO LOS ANGELES CA                 -> WELLS FARGO
CITIBANK 200 PARK AVE NEW YORK NY 10166    -> CITIBANK
CHASE NEW YORK NY                          -> CHASE
JPMORGAN MANHATTAN NY                      -> JPMORGAN
```

## 3. Title/subtitle still cramped on competition donut slides
The PR #93 sweep didn't catch `competition/61_banks_only_donut.py` and `competition/61_core_competition_donut.py` — they use `suptitle(y=1.02) + fig.text(y=0.965)`, only ~0.055 of figure height between visible title and subtitle. Push subtitle to y=0.92 and title to y=1.00 for consistent ~0.08 clearance.

## 4. ARS branch name regression (1200 showing numeric branches)
`rege/branches.py:_branch_rates` and `dctr/_helpers.py:branch_dctr` coerced mapping keys to strings, but `Branch` column values arrive as floats from pandas (`'1.0'`, `'2.0'`, ...). `str(1.0) = '1.0'` did not hit BranchMapping key `'1'`, so 1200's 8 named branches (West Palm Beach, Boynton Beach, Old Royal Palm, Fort Pierce, VMRC, Royal Palm Beach, Miami, Admin) rendered as `'1.0'`, `'2.0'`, etc. Add a `.split('.')[0]` fallback in both lookup paths (the TXN-side loader had this; ARS-side didn't).

## What's NOT in this PR (still open)

- **Top 25 Fed District showing 0 for SE Florida** — needs a real run to diagnose. After this aggregation fix lands, the Fed District 6 patterns should hit (SEACOAST/SYNOVUS/REGIONS/etc) more often. If still 0 in next run, share the diagnostic output.
- **Financial services category-leakage vs top-merchants inconsistency** (74 credit monitoring vs 577 Progressive in top 15) — needs a fresh log + numbers to determine whether it's a counting bug or just two different metrics.
- **Sweep title/subtitle spacing across remaining ~100 chart files** — separate sweep PR; the helper is already in place.

## Files changed
- `01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py`
- `01_Analysis/00-Scripts/analytics/competition/61_banks_only_donut.py`
- `01_Analysis/00-Scripts/analytics/competition/61_core_competition_donut.py`
- `01_Analysis/00-Scripts/analytics/dctr/_helpers.py`
- `01_Analysis/00-Scripts/analytics/rege/branches.py`
- `01_Analysis/00-Scripts/analytics/txn_setup/06-merchant-name-consolidation.py`