### PR TITLE
feat(w1): denominator-law enforcement + has_debit consolidation

### DIFF
--- a/01_Analysis/00-Scripts/analytics/base.py
+++ b/01_Analysis/00-Scripts/analytics/base.py
@@ -38,6 +38,13 @@ class AnalysisResult:
     kpis: dict[str, str] | None = None
     extra_charts: list[Path] | None = None
     bullets: list[str] | None = None
+    # Denominator label per the 4-layer framework: one of
+    # "Eligible", "Eligible Personal", "Eligible Business", "Open".
+    # Empty string means "not a rate" (chart, dollar figure unrelated to a rate, etc.).
+    # Modules SHOULD stamp this on any result that surfaces a rate/ratio/share.
+    # Wave 1: audit step infers default per slide_id when this is empty.
+    denominator_label: str = ""
+    denominator_n: int = 0
 
 
 class AnalysisModule(ABC):

--- a/01_Analysis/00-Scripts/analytics/dctr/_helpers.py
+++ b/01_Analysis/00-Scripts/analytics/dctr/_helpers.py
@@ -38,25 +38,14 @@ BALANCE_ORDER = [
 
 # -- Debit column detection (shared by DCTR, Reg E, Value) -------------------
 
-_DEBIT_CANDIDATES = ("Debit?", "Debit", "DC Indicator", "DC_Indicator")
-_DEBIT_YES_VALUES = frozenset(("YES", "Y", "D", "DC", "DEBIT"))
-
-
-def detect_debit_col(df: pd.DataFrame) -> str | None:
-    """Auto-detect the debit card column name from a DataFrame."""
-    for c in _DEBIT_CANDIDATES:
-        if c in df.columns:
-            return c
-    return None
-
-
-def debit_mask(df: pd.DataFrame, col: str | None = None) -> pd.Series:
-    """Return boolean mask for 'has debit card' regardless of column name or coding convention."""
-    if col is None:
-        col = detect_debit_col(df)
-    if col is None or col not in df.columns:
-        return pd.Series(False, index=df.index)
-    return df[col].astype(str).str.strip().str.upper().isin(_DEBIT_YES_VALUES)
+# Canonical debit detection lives in ars_analysis.shared.debit. Re-exported here
+# so all existing analytics imports (`from ...dctr._helpers import debit_mask`) keep working.
+from ars_analysis.shared.debit import (  # noqa: F401
+    DEBIT_CANDIDATES as _DEBIT_CANDIDATES,
+    DEBIT_YES_VALUES as _DEBIT_YES_VALUES,
+    debit_mask,
+    detect_debit_col,
+)
 
 
 # -- Core DCTR calculation ---------------------------------------------------

--- a/01_Analysis/00-Scripts/analytics/dctr/penetration.py
+++ b/01_Analysis/00-Scripts/analytics/dctr/penetration.py
@@ -35,11 +35,28 @@ from ars_analysis.pipeline.context import PipelineContext
 
 
 def _safe(fn, label: str, ctx: PipelineContext) -> list[AnalysisResult]:
-    """Run analysis function, catch errors, return failed result on exception."""
+    """Run analysis function, catch errors, return failed result on exception.
+
+    On failure: top-level WARN log + AnomalyFlag(WARN) on the manifest so the
+    silent path becomes noisy in run_scorecard.md and the UI completion card.
+    """
     try:
         return fn(ctx)
     except Exception as exc:
         logger.warning("{label} failed: {err}", label=label, err=exc)
+        _mf = getattr(ctx, "manifest", None)
+        if _mf is not None:
+            try:
+                from ars_analysis.pipeline.manifest import AnomalyFlag, FlagLevel
+                for _sec in _mf.sections:
+                    if _sec.name == "dctr":
+                        _sec.anomaly_flags.append(AnomalyFlag(
+                            level=FlagLevel.WARN,
+                            message=f"{label}: {type(exc).__name__}: {exc}",
+                        ))
+                        break
+            except Exception:
+                pass
         return [
             AnalysisResult(
                 slide_id=label,

--- a/01_Analysis/00-Scripts/analytics/insights/_data.py
+++ b/01_Analysis/00-Scripts/analytics/insights/_data.py
@@ -11,11 +11,27 @@ from ars_analysis.pipeline.context import PipelineContext
 
 
 def _safe(fn, label: str, ctx: PipelineContext) -> list[AnalysisResult]:
-    """Run analysis function, catch errors, return failed result on exception."""
+    """Run analysis function, catch errors, return failed result on exception.
+
+    On failure: top-level WARN log + AnomalyFlag(WARN) on the manifest.
+    """
     try:
         return fn(ctx)
     except Exception as exc:
         logger.warning("{label} failed: {err}", label=label, err=exc)
+        _mf = getattr(ctx, "manifest", None)
+        if _mf is not None:
+            try:
+                from ars_analysis.pipeline.manifest import AnomalyFlag, FlagLevel
+                for _sec in _mf.sections:
+                    if _sec.name == "insights":
+                        _sec.anomaly_flags.append(AnomalyFlag(
+                            level=FlagLevel.WARN,
+                            message=f"{label}: {type(exc).__name__}: {exc}",
+                        ))
+                        break
+            except Exception:
+                pass
         return [
             AnalysisResult(
                 slide_id=label,

--- a/01_Analysis/00-Scripts/analytics/insights/branch_scorecard.py
+++ b/01_Analysis/00-Scripts/analytics/insights/branch_scorecard.py
@@ -28,12 +28,38 @@ MIN_BRANCHES = 3
 
 
 def _build_branch_data(ctx: PipelineContext) -> pd.DataFrame | None:
-    """Assemble branch-level metrics from upstream results.
+    """Assemble branch-level metrics from the eligible base (4-layer denominator law).
+
+    Per project_denominator_framework.md (LAW): DCTR / Reg E / attrition rates anchor
+    to the Eligible layer. Reading raw ctx.data inflates the denominator with closed
+    accounts and conflicts with the detail slides. Read ctx.subsets.eligible_data;
+    fall back to raw only when the subset is missing (with a manifest WARN flag).
 
     Returns DataFrame with columns: branch, dctr, rege_rate, attrition_rate, n_accounts.
     Returns None if insufficient data.
     """
-    data = ctx.data
+    ed = ctx.subsets.eligible_data if ctx.subsets is not None else None
+    if ed is not None and not ed.empty:
+        data = ed
+    else:
+        data = ctx.data
+        logger.warning(
+            "branch_scorecard: eligible_data missing; falling back to raw ctx.data "
+            "(denominator may not match detail slides)"
+        )
+        _mf = getattr(ctx, "manifest", None)
+        if _mf is not None:
+            try:
+                from ars_analysis.pipeline.manifest import AnomalyFlag, FlagLevel
+                for _sec in _mf.sections:
+                    if _sec.name == "insights":
+                        _sec.anomaly_flags.append(AnomalyFlag(
+                            level=FlagLevel.WARN,
+                            message="branch_scorecard fallback to raw ctx.data",
+                        ))
+                        break
+            except Exception:
+                pass
     if data is None:
         return None
 
@@ -46,12 +72,9 @@ def _build_branch_data(ctx: PipelineContext) -> pd.DataFrame | None:
     if branch_col is None:
         return None
 
-    # Detect debit column
-    debit_col = None
-    for col in ("Debit?", "Debit", "DC Indicator"):
-        if col in data.columns:
-            debit_col = col
-            break
+    # Detect debit column (canonical)
+    from ars_analysis.shared.debit import detect_debit_col, debit_mask
+    debit_col = detect_debit_col(data)
 
     # Compute per-branch metrics from raw data
     branches = data[branch_col].dropna().unique()
@@ -68,7 +91,7 @@ def _build_branch_data(ctx: PipelineContext) -> pd.DataFrame | None:
         # DCTR: debit holders / total
         dctr = 0.0
         if debit_col:
-            n_debit = len(branch_data[branch_data[debit_col].isin(["Yes", "Y", True, 1])])
+            n_debit = int(debit_mask(branch_data, debit_col).sum())
             dctr = n_debit / n_total
 
         # Attrition: closed / total

--- a/01_Analysis/00-Scripts/analytics/insights/dormant.py
+++ b/01_Analysis/00-Scripts/analytics/insights/dormant.py
@@ -26,11 +26,10 @@ AVG_ANNUAL_IC = 216.0  # PULSE benchmark per active card
 # ---------------------------------------------------------------------------
 
 
-def _detect_debit_col(df: pd.DataFrame) -> str | None:
-    for col in ("Debit?", "Debit", "DC Indicator"):
-        if col in df.columns:
-            return col
-    return None
+from ars_analysis.shared.debit import (
+    debit_mask as _debit_mask,
+    detect_debit_col as _detect_debit_col,
+)
 
 
 def _detect_spend_cols(df: pd.DataFrame) -> list[str]:
@@ -59,7 +58,7 @@ def _find_dormant_accounts(df: pd.DataFrame) -> pd.DataFrame | None:
     if bal_col is None:
         return None
 
-    no_debit = df[~df[debit_col].isin(["Yes", "Y", True, 1])].copy()
+    no_debit = df[~_debit_mask(df, debit_col)].copy()
     if len(no_debit) == 0:
         return None
 

--- a/01_Analysis/00-Scripts/analytics/mailer/reach.py
+++ b/01_Analysis/00-Scripts/analytics/mailer/reach.py
@@ -78,17 +78,14 @@ def _organic_activation(
 
     Returns dict with counts and rates.
     """
-    # Detect debit column
-    debit_col = None
-    for col in ("Debit?", "Debit", "DC Indicator"):
-        if col in data.columns:
-            debit_col = col
-            break
+    # Detect debit column (canonical)
+    from ars_analysis.shared.debit import detect_debit_col, has_debit as _has_debit
+    debit_col = detect_debit_col(data)
 
     if debit_col is None:
         return {"organic": 0, "mailed_resp": 0, "mailed_non_resp": 0, "total_debit": 0}
 
-    has_debit = data[data[debit_col].isin(["Yes", "Y", True, 1])]
+    has_debit = _has_debit(data, debit_col)
 
     # Build ever-mailed mask
     ever_mailed = pd.Series(False, index=data.index)

--- a/01_Analysis/00-Scripts/analytics/rege/status.py
+++ b/01_Analysis/00-Scripts/analytics/rege/status.py
@@ -21,11 +21,27 @@ from ars_analysis.pipeline.context import PipelineContext
 
 
 def _safe(fn, label: str, ctx: PipelineContext) -> list[AnalysisResult]:
-    """Run analysis function, catch errors, return failed result on exception."""
+    """Run analysis function, catch errors, return failed result on exception.
+
+    On failure: top-level WARN log + AnomalyFlag(WARN) on the manifest.
+    """
     try:
         return fn(ctx)
     except Exception as exc:
         logger.warning("{label} failed: {err}", label=label, err=exc)
+        _mf = getattr(ctx, "manifest", None)
+        if _mf is not None:
+            try:
+                from ars_analysis.pipeline.manifest import AnomalyFlag, FlagLevel
+                for _sec in _mf.sections:
+                    if _sec.name == "rege":
+                        _sec.anomaly_flags.append(AnomalyFlag(
+                            level=FlagLevel.WARN,
+                            message=f"{label}: {type(exc).__name__}: {exc}",
+                        ))
+                        break
+            except Exception:
+                pass
         return [
             AnalysisResult(
                 slide_id=label,

--- a/01_Analysis/00-Scripts/pipeline/steps/audit.py
+++ b/01_Analysis/00-Scripts/pipeline/steps/audit.py
@@ -1,0 +1,187 @@
+"""Step: per-run denominator-law audit.
+
+Writes rates_audit.csv next to run_manifest.json, one row per slide that ships
+a rate, recording the denominator the rate was computed against. Validates each
+row against the 4-layer framework (Eligible / Eligible Personal / Eligible Business
+/ Open) and emits AnomalyFlag(WARN) on the run manifest for every violation.
+
+Per project_denominator_framework.md (LAW):
+- Eligible is the primary default.
+- Eligible Personal / Eligible Business are sub-views for inherently personal-
+  or business-only metrics.
+- Open is reference framing only. Allowed as primary denominator on the methodology
+  slide DCTR-2 only; flagged anywhere else.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from loguru import logger
+
+from ars_analysis.pipeline.context import PipelineContext
+
+LAW_LABELS: frozenset[str] = frozenset((
+    "Eligible",
+    "Eligible Personal",
+    "Eligible Business",
+    "Open",
+))
+
+# Slides explicitly permitted to use Open as primary denominator (reference framing).
+OPEN_ALLOWLIST: frozenset[str] = frozenset((
+    "dctr_2",       # Open vs Eligible methodology slide
+    "DCTR-2",
+))
+
+# Default denominator label per slide_id prefix. Modules can override by stamping
+# `denominator_label` on the AnalysisResult directly.
+DEFAULT_BY_PREFIX: dict[str, str] = {
+    "dctr_": "Eligible",
+    "DCTR-": "Eligible",
+    "rege_": "Eligible Personal",
+    "REGE-": "Eligible Personal",
+    "reg_e_": "Eligible Personal",
+    "attrition_": "Eligible",
+    "A9": "Eligible",
+    "mailer_": "Eligible",
+    "value_": "Eligible",
+    "A11": "Eligible",
+    "insights_": "Eligible",
+    "S1": "Eligible",
+    "S6": "Eligible",
+    "S8": "Eligible",
+    "branch_scorecard": "Eligible",
+    "a19_": "Eligible",
+    "overview_": "Eligible",
+    "A1": "Eligible",
+}
+
+
+def _default_label(slide_id: str) -> str:
+    """Infer the default denominator label for a slide_id when modules haven't stamped one."""
+    for prefix, label in DEFAULT_BY_PREFIX.items():
+        if slide_id.startswith(prefix):
+            return label
+    return ""
+
+
+def _looks_like_rate(result) -> bool:
+    """True if the result surfaces a rate/ratio/share."""
+    # Explicit stamp wins
+    if getattr(result, "denominator_label", ""):
+        return True
+    # Heuristic: kpis containing a "%" or "rate" key
+    kpis = getattr(result, "kpis", None) or {}
+    for k, v in kpis.items():
+        kl = str(k).lower()
+        if "rate" in kl or "%" in kl or "share" in kl or "pct" in kl:
+            return True
+        vs = str(v)
+        if vs.endswith("%") or "pp" in vs:
+            return True
+    return False
+
+
+def write_rates_audit(ctx: PipelineContext) -> tuple[Path | None, int]:
+    """Write rates_audit.csv and return (path, violation_count).
+
+    Walks ctx.all_slides, emits one row per slide that ships a rate, defaults the
+    denominator label from a per-section registry when modules haven't stamped one,
+    and flags any row whose label is not in the 4-layer law.
+    """
+    out_dir = ctx.paths.base_dir
+    if out_dir is None:
+        return None, 0
+
+    path = out_dir / "rates_audit.csv"
+    rows: list[dict[str, object]] = []
+    violations = 0
+
+    for result in getattr(ctx, "all_slides", []) or []:
+        if not _looks_like_rate(result):
+            continue
+
+        slide_id = getattr(result, "slide_id", "") or getattr(result, "name", "")
+        label = getattr(result, "denominator_label", "") or _default_label(slide_id)
+        denom_n = int(getattr(result, "denominator_n", 0) or 0)
+        title = getattr(result, "title", "")
+        kpis = getattr(result, "kpis", None) or {}
+
+        # Compliance: must be in LAW_LABELS; Open only on the allowlist
+        compliant = True
+        violation_reason = ""
+        if label not in LAW_LABELS:
+            compliant = False
+            violation_reason = f"label '{label}' not in 4-layer framework"
+        elif label == "Open" and slide_id not in OPEN_ALLOWLIST:
+            compliant = False
+            violation_reason = "Open used as primary denominator outside reference allowlist"
+
+        if not compliant:
+            violations += 1
+
+        # Pick a representative metric value to show in the CSV
+        metric_name = ""
+        metric_value = ""
+        for k, v in kpis.items():
+            kl = str(k).lower()
+            if "rate" in kl or "%" in kl or "share" in kl:
+                metric_name = str(k)
+                metric_value = str(v)
+                break
+
+        rows.append({
+            "slide_id": slide_id,
+            "title": title,
+            "metric": metric_name,
+            "value": metric_value,
+            "denominator_label": label,
+            "denominator_n": denom_n,
+            "framework_compliant": compliant,
+            "violation_reason": violation_reason,
+        })
+
+    if not rows:
+        logger.info("rates_audit: no rate-bearing slides found; skipping write")
+        return None, 0
+
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+        logger.info(
+            "rates_audit.csv: {n} rates, {v} law violations",
+            n=len(rows), v=violations,
+        )
+    except Exception as exc:
+        logger.warning("rates_audit write failed: {err}", err=exc)
+        return None, violations
+
+    # Surface violations on the manifest
+    _mf = getattr(ctx, "manifest", None)
+    if _mf is not None and violations > 0:
+        try:
+            from ars_analysis.pipeline.manifest import AnomalyFlag, FlagLevel
+            # Attach to the first section as a run-wide flag; scorecard surfaces it.
+            target = _mf.sections[0] if _mf.sections else None
+            if target is not None:
+                target.anomaly_flags.append(AnomalyFlag(
+                    level=FlagLevel.WARN,
+                    message=f"Denominator law: {violations} violation(s) (see rates_audit.csv)",
+                ))
+        except Exception as exc:
+            logger.warning("manifest flag for rates_audit failed: {err}", err=exc)
+
+    return path, violations
+
+
+def step_audit(ctx: PipelineContext) -> None:
+    """Pipeline step entrypoint. Never raises (audit failure cannot break the run)."""
+    try:
+        write_rates_audit(ctx)
+    except Exception as exc:
+        logger.warning("rates_audit step failed: {err}", err=exc)

--- a/01_Analysis/00-Scripts/pipeline/steps/generate.py
+++ b/01_Analysis/00-Scripts/pipeline/steps/generate.py
@@ -142,6 +142,15 @@ def step_generate(ctx: PipelineContext) -> None:
     _build_aux_deck(ctx)
     logger.info("Deliverables generated for {client}", client=ctx.client.client_id)
 
+    # Wave 1: denominator-law audit. Walks ctx.all_slides, writes rates_audit.csv,
+    # flags any rate whose denominator label is not in the 4-layer framework.
+    # Runs before the scorecard so violations are visible in the scorecard summary.
+    try:
+        from ars_analysis.pipeline.steps.audit import step_audit
+        step_audit(ctx)
+    except Exception as _exc:
+        logger.warning("rates_audit step failed: {err}", err=_exc)
+
     # Post-run scorecard derived from the manifest. Optional: only runs if
     # the manifest was set up. Failures here never break the pipeline.
     _mf = getattr(ctx, "manifest", None)

--- a/01_Analysis/00-Scripts/shared/debit.py
+++ b/01_Analysis/00-Scripts/shared/debit.py
@@ -1,0 +1,48 @@
+"""Canonical 'has debit card' detection.
+
+Single source of truth so every analytics module agrees on:
+1. Which column to read (auto-detect across known aliases).
+2. Which values count as 'has debit' (string codes + booleans + ints).
+
+Before this module existed, four divergent definitions lived in:
+- analytics/dctr/_helpers.py (the most permissive set)
+- analytics/insights/dormant.py (string-only)
+- analytics/insights/branch_scorecard.py (string-only)
+- analytics/mailer/reach.py (allowed booleans and 1, but used "Yes/Y/True/1" only)
+
+They disagreed on cases like `True`, `1`, `"D"`, `"DC"`, producing different
+debit-holder counts across modules for the same client.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+DEBIT_CANDIDATES: tuple[str, ...] = ("Debit?", "Debit", "DC Indicator", "DC_Indicator")
+DEBIT_YES_VALUES: frozenset[str] = frozenset(("YES", "Y", "TRUE", "1", "D", "DC", "DEBIT"))
+
+
+def detect_debit_col(df: pd.DataFrame) -> str | None:
+    """Return the first known debit-card column present in df, or None."""
+    for c in DEBIT_CANDIDATES:
+        if c in df.columns:
+            return c
+    return None
+
+
+def debit_mask(df: pd.DataFrame, col: str | None = None) -> pd.Series:
+    """Boolean mask: True where the row has a debit card.
+
+    Tolerates string codes (Yes/Y/D/DC/Debit), booleans (True/False),
+    and integer flags (1/0). Empty / NaN / unknown values become False.
+    """
+    if col is None:
+        col = detect_debit_col(df)
+    if col is None or col not in df.columns:
+        return pd.Series(False, index=df.index)
+    return df[col].astype(str).str.strip().str.upper().isin(DEBIT_YES_VALUES)
+
+
+def has_debit(df: pd.DataFrame, col: str | None = None) -> pd.DataFrame:
+    """Return the subset of df where the row has a debit card."""
+    return df[debit_mask(df, col)]

--- a/01_Analysis/00-Scripts/tests/test_audit.py
+++ b/01_Analysis/00-Scripts/tests/test_audit.py
@@ -1,0 +1,128 @@
+"""Tests for the rates_audit denominator-law enforcement step."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from ars_analysis.pipeline.steps.audit import (
+    DEFAULT_BY_PREFIX,
+    LAW_LABELS,
+    OPEN_ALLOWLIST,
+    _default_label,
+    _looks_like_rate,
+    write_rates_audit,
+)
+
+
+@dataclass
+class _FakeResult:
+    slide_id: str = ""
+    title: str = ""
+    kpis: dict | None = None
+    denominator_label: str = ""
+    denominator_n: int = 0
+    success: bool = True
+
+
+@dataclass
+class _FakePaths:
+    base_dir: Path | None = None
+
+
+@dataclass
+class _FakeCtx:
+    all_slides: list = field(default_factory=list)
+    paths: _FakePaths = field(default_factory=_FakePaths)
+    manifest: object = None
+
+
+def test_law_labels_are_the_four_layers():
+    assert LAW_LABELS == frozenset((
+        "Eligible", "Eligible Personal", "Eligible Business", "Open",
+    ))
+
+
+def test_open_allowlist_contains_dctr_2():
+    assert "dctr_2" in OPEN_ALLOWLIST
+    assert "DCTR-2" in OPEN_ALLOWLIST
+
+
+def test_default_label_dctr_is_eligible():
+    assert _default_label("dctr_1") == "Eligible"
+    assert _default_label("DCTR-7") == "Eligible"
+
+
+def test_default_label_rege_is_eligible_personal():
+    assert _default_label("rege_1") == "Eligible Personal"
+    assert _default_label("REGE-2") == "Eligible Personal"
+
+
+def test_default_label_unknown_returns_empty():
+    assert _default_label("unknown_slide_xyz") == ""
+
+
+def test_looks_like_rate_detects_rate_kpis():
+    r = _FakeResult(kpis={"DCTR Rate": "30%"})
+    assert _looks_like_rate(r) is True
+
+
+def test_looks_like_rate_detects_explicit_stamp():
+    r = _FakeResult(denominator_label="Eligible")
+    assert _looks_like_rate(r) is True
+
+
+def test_looks_like_rate_skips_non_rate():
+    r = _FakeResult(kpis={"Total Accounts": "12,345"})
+    assert _looks_like_rate(r) is False
+
+
+def test_write_rates_audit_creates_csv_and_flags_violations(tmp_path):
+    ctx = _FakeCtx()
+    ctx.paths = _FakePaths(base_dir=tmp_path)
+    ctx.all_slides = [
+        _FakeResult(slide_id="dctr_1", title="DCTR Overall",
+                    kpis={"DCTR Rate": "30%"}),  # default → Eligible (compliant)
+        _FakeResult(slide_id="rege_1", title="Reg E Overall",
+                    kpis={"Opt-In Rate": "45%"}),  # default → Eligible Personal
+        _FakeResult(slide_id="mystery_1", title="Mystery",
+                    kpis={"Some Rate": "10%"}),  # no default → empty label (violation)
+        _FakeResult(slide_id="dctr_2", title="Open vs Eligible",
+                    kpis={"DCTR Rate": "80%"},
+                    denominator_label="Open"),  # Open allowed on dctr_2
+        _FakeResult(slide_id="value_1", title="Revenue",
+                    kpis={"Penetration Rate": "60%"},
+                    denominator_label="Open"),  # Open NOT allowed here (violation)
+    ]
+
+    path, violations = write_rates_audit(ctx)
+    assert path is not None
+    assert path.name == "rates_audit.csv"
+    assert violations == 2
+
+    with open(path) as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 5
+    by_id = {r["slide_id"]: r for r in rows}
+    assert by_id["dctr_1"]["framework_compliant"] == "True"
+    assert by_id["dctr_1"]["denominator_label"] == "Eligible"
+    assert by_id["rege_1"]["denominator_label"] == "Eligible Personal"
+    assert by_id["mystery_1"]["framework_compliant"] == "False"
+    assert by_id["dctr_2"]["framework_compliant"] == "True"
+    assert by_id["value_1"]["framework_compliant"] == "False"
+    assert "Open" in by_id["value_1"]["violation_reason"]
+
+
+def test_write_rates_audit_returns_none_when_no_rate_slides(tmp_path):
+    ctx = _FakeCtx()
+    ctx.paths = _FakePaths(base_dir=tmp_path)
+    ctx.all_slides = [
+        _FakeResult(slide_id="dctr_1", title="DCTR", kpis={"Total": "100"}),
+    ]
+    path, violations = write_rates_audit(ctx)
+    assert path is None
+    assert violations == 0
+    assert not (tmp_path / "rates_audit.csv").exists()

--- a/docs/WORKFLOW_MAP.md
+++ b/docs/WORKFLOW_MAP.md
@@ -1,0 +1,118 @@
+# RPE-Workflow — Pipeline Visual Map
+
+End-to-end map of the Velocity Pipeline: from raw ODD ZIPs in a CSM's data dump folder to a finished PowerPoint deck. All three steps are driven by the UI at `05_UI/`; the `run.py` entrypoints are the same code paths, exposed for batch/debug.
+
+---
+
+## Visual map
+
+```
+                     ┌──────────────────────────────────────────┐
+                     │   OPERATOR (CSM)  —  Browser at :8000    │
+                     │   05_UI/index.html  ←→  05_UI/app.py     │
+                     └──────────────────────────────────────────┘
+                                       │
+        ┌──────────────────────────────┼────────────────────────────┐
+        ▼                              ▼                            ▼
+   ┌─────────┐                    ┌─────────┐                  ┌─────────┐
+   │ STEP 1  │                    │ STEP 2  │                  │ STEP 3  │
+   │ FORMAT  │  ───────────────►  │ ANALYZE │  ──────────────► │  DECK   │
+   └─────────┘                    └─────────┘                  └─────────┘
+
+ INPUT                          INPUT                          INPUT
+ ─────                          ─────                          ─────
+ Raw ODD ZIPs in                Formatted ODD .xlsx            Completed analysis
+ M:\<CSM>\OD Data Dumps\        + (optional) TXN CSVs          (Excel + chart PNGs
+ <period>\<client>_ODDD.zip     + deferred / workbook            + run_manifest.json)
+                                                                + SLIDE_MANIFEST.xlsx
+
+ SCRIPT                         SCRIPT                         SCRIPT
+ ──────                         ──────                         ──────
+ 00_Formatting/run.py           01_Analysis/run.py             02_Presentations/
+   └ pipeline/retrieve.py         └ pipeline/runner.py           html_review/builder.py
+   └ pipeline/format.py           └ pipeline/steps/              (called by
+   └ shared/format_odd.py             load → scan → analyze       01_Analysis/.../output/
+                                      → generate → format         deck builder)
+
+ WHAT IT DOES                   WHAT IT DOES                   WHAT IT DOES
+ ────────────                   ────────────                   ────────────
+ 1. Unzip raw ODD               Runs 25 ARS modules and/or     Reads SLIDE_MANIFEST
+ 2. Convert .csv → .xlsx        22 TXN sections registered     (Keep? Y / A / N),
+ 3. 7-step ODD format           in analytics/registry.py.      stitches charts +
+ 4. Stage TXN files             Each module:                   action titles into
+ 5. Pull deferred-rev rows        - reads formatted ODD         python-pptx slides.
+ 6. Pull R: workbook              - builds a DataFrame
+                                  - writes chart PNG(s)        Routes:
+                                  - writes Excel sheet          Y → main deck
+                                  - records status in           A → _aux_deck
+                                    run_manifest.json           N → dropped
+
+ OUTPUT                         OUTPUT                         OUTPUT
+ ──────                         ──────                         ──────
+ 00_Formatting/                 01_Analysis/                   02_Presentations/
+ 02-Data-Ready for Analysis/    01_Completed_Analysis/         <CSM>/<period>/<client>/
+   <CSM>/<period>/<client>/       <CSM>/<period>/<client>/       <id>_<month>_
+     <id>_ODD_formatted.xlsx        charts/*.png                   ars_deck.pptx
+     trans/*.csv  (if TXN)          analysis_workbook.xlsx         ars_aux_deck.pptx
+     deferred_revenue.xlsx          run_manifest.json              review_summary.xlsx
+     workbook.xlsx                  run_scorecard.md               quality_report.txt
+                                    competition_diagnostic.txt     meta.json
+```
+
+---
+
+## Step 1 — FORMAT
+
+*Format tab in the UI.*
+
+- **Script:** `00_Formatting/run.py` → `pipeline/retrieve.py` (find + unzip) → `pipeline/format.py` → `shared/format_odd.py` (7-step transform)
+- **API:** `POST /api/format` in `05_UI/app.py`
+- **Analysis:** Mechanical — no metrics. Normalizes columns, coerces types, splits personal/business, applies stat-code and product-code lookups from `03_Config/clients_config.json`, optionally gathers TXN / deferred / workbook side files.
+- **Output:** `00_Formatting/02-Data-Ready for Analysis/<CSM>/<period>/<client>/<id>_ODD_formatted.xlsx` (+ `trans/`, `deferred_revenue.xlsx`, `workbook.xlsx` if requested). This file is the contract for Step 2.
+
+---
+
+## Step 2 — ANALYZE
+
+*Generate tab — "Run analytics" stage.*
+
+- **Script:** `01_Analysis/run.py` → `00-Scripts/pipeline/runner.py` orchestrates `pipeline/steps/{load, scan, subsets, analyze, generate, format}.py`
+- **Module registry:** `00-Scripts/analytics/registry.py` enumerates 25 ARS modules + (per `--product`) 22 TXN sections wrapped by `analytics/txn_wrapper.py`
+- **API:** `POST /api/generate` in `app.py` streams the 5-stage checklist
+- **Analysis (ARS, 25 modules):** `overview` (3) · `dctr` debit-card take-rate (5) · `rege` Reg-E opt-in (3) · `attrition` (3) · `mailer` campaign (5) · `value` revenue (1) · `insights` synthesis (5). Each rate anchors to one of the 4 denominator layers (`Eligible / Eligible Personal / Eligible Business / Open`).
+- **Analysis (TXN sections, when `--product=txn` or `combined`):** `txn_setup` shared loaders + ~22 sections (`general, merchant, mcc_code, competition, financial_services, ics_acquisition, campaign, branch_txn, transaction_type, product, attrition_txn, balance, interchange, rege_overdraft, payroll, relationship, segment_evolution, retention, engagement, executive`, etc.).
+- **Output:** `01_Analysis/01_Completed_Analysis/<CSM>/<period>/<client>/`
+  - `charts/*.png` — every chart for the deck
+  - `analysis_workbook.xlsx` — every table behind every chart
+  - `run_manifest.json` — per-module status + suggested fixes (schema in `docs/manifest-schema.md`)
+  - `run_scorecard.md` — one-page pass/fail summary
+  - `competition_diagnostic.txt` — category counts, BNPL audit, unmatched financial keywords
+
+---
+
+## Step 3 — BUILD DECK
+
+*Generate tab — "Build PowerPoint" stage.*
+
+- **Script:** Deck builder in `01_Analysis/00-Scripts/output/` (action-title populator + python-pptx layouts); HTML preview by `02_Presentations/html_review/builder.py`
+- **Inputs it reads:**
+  - Charts + workbook from Step 2
+  - `SLIDE_MANIFEST.xlsx` (operator's `Keep? Y/A/N` column)
+  - `docs/action_title_templates.md` (28 reusable headlines)
+  - `SLIDE_DESIGN.md` (palette, typography, callouts)
+- **Analysis:** No new math. Maps each chart → slide layout → action-title template, fills `ctx.results` placeholders, splits `Y` vs `A` into two decks, drops `N`.
+- **Output:** `02_Presentations/<CSM>/<period>/<client>/`
+  - `<id>_<month>_ars_deck.pptx` (or `_txn_deck.pptx` / `_combined_deck.pptx`)
+  - `<id>_<month>_ars_aux_deck.pptx` (appendix, if any `A`s)
+  - `<id>_<month>_review_summary.xlsx` (4-sheet CSM review)
+  - `<id>_<month>_quality_report.txt` (10 automated checks)
+  - `<id>_<month>_meta.json` (audit trail)
+  - Cross-sell candidate CSVs in `Actionable Lists for Clients/<client>_<name>/cross_sell_lists/`
+
+---
+
+## Cross-cutting
+
+- **Driver:** `05_UI/app.py` is the single orchestrator. Every step above also runs from `run.py` on the CLI for batch/debug, but operators only ever click buttons.
+- **Per-CSM membership:** no master mapping; a client "belongs" to a CSM by the folder their files sit in at any of the three stages (raw / formatted / completed). `app.py` unions all three for the dropdown.
+- **Products** (`--product` flag): `ARS Full Suite` (default, ODD only) · `Transaction` · `Combined` · `Deposits`. Each emits a distinctly-named deck so runs don't clobber each other.

--- a/docs/plans/2026-06-04-velocity-pipeline-accuracy-and-design.md
+++ b/docs/plans/2026-06-04-velocity-pipeline-accuracy-and-design.md
@@ -1,0 +1,360 @@
+# Velocity Pipeline — Analysis Flow, Accuracy, CSM Experience, and Slide Redesign
+
+## Context
+
+The Velocity pipeline shipped fast and grew across many hands. A static data‑quality audit (`docs/audits/2026-04-17-data-quality-audit.md`) and a fresh read of the code turn up three classes of problem that compound:
+
+1. **The numbers are wrong.** Every DCTR rate (and every dollar figure built on top of it — value, S1–S8 insights, executive KPI dashboard, benchmark comparisons) is computed against `ctx.subsets.eligible_data`, a narrowed subset of open accounts ∩ eligible stat codes ∩ eligible product codes. The notebook of record uses a broader denominator. The pipeline reports ~30% DCTR where the notebook reports ~80%; the gap propagates straight into the headline dollar numbers a CSM presents to a CEO. Reg E sits on an even narrower base (`eligible_personal ∩ has_debit`) labeled as a portfolio rate. `insights/branch_scorecard.py` reimplements DCTR/attrition/Reg E against the raw frame and ships numbers that don't match the detail slides.
+2. **There is no single source of truth for the brand.** Five different navies (`#1A1A1A`, `#00274C`, `#1E3D59`, `#1B365D`, `#2E4057`) and three different accents are scattered across the README, UI, `SLIDE_DESIGN.md`, `SLIDE_MAPPING.md`, `shared/charts.py`, `charts/style.py`, `output/excel_formatter.py`, `output/deck_builder.py`, and ~65 analytics files using legacy semantic aliases (PERSONAL/BUSINESS/HISTORICAL/TTM). Two color authorities (`shared/charts.py` and `charts/style.py`) disagree.
+3. **The deck doesn't follow its own design system.** `SLIDE_DESIGN.md` describes a McKinsey-grade slide anatomy (action title, callout, footer band, SCQA arc) but only two per-section specs exist (`dctr.md`, `rege.md`) and the rest of the deck ships matplotlib titles and generic boilerplate. Headlines for ~40% of slides fall back to category names because the registry is full of `_noop`. There are TWO separate deck-builder code paths (`deck_builder.py`, `sales_deck_builder.py`) and an unused `sample_deck_builder.py`.
+
+Operator-facing impact: a CSM clicks Generate, waits 15–25 minutes, and gets a deck whose key numbers are off and whose visuals don't match the design doc. The Format tab still uses the legacy progress bar; the run scorecard (`run_scorecard.md`) is written but never surfaced in the UI; the slide manifest's Keep/Aux/Drop decisions are edited in Excel rather than in the product. This is fixable — most of the right pieces already exist, they just need to be wired together and made consistent.
+
+User-confirmed scope:
+- **Canonical brand** = CSI brand (README/UI): navy `#1A1A1A`, accent orange `#F15D22`, Montserrat / Space Mono — everything else aligns to it.
+- **Include denominator fix** as the P0 work item.
+
+## Shape of the change
+
+```mermaid
+flowchart TB
+  subgraph W1["Wave 1 — Truth (P0, ~1 wk)"]
+    A1["Canonical denominators in subsets.py<br/>(open / eligible / debit / l12m)"] --> A2
+    A2["DCTR + RegE + Value + Insights<br/>read subsets.canonical_*"] --> A3
+    A3["branch_scorecard pulls from<br/>ctx.results, not raw df"]
+    A4["rates_audit.csv per run<br/>(every rate + denominator + N)"]
+    A1 --> A4
+  end
+
+  subgraph W2["Wave 2 — Brand (~3 days)"]
+    B1["brand.py = single color/font authority<br/>(CSI orange + #1A1A1A navy)"] --> B2
+    B2["charts/style.py + shared/charts.py +<br/>excel_formatter aliases → brand.py"] --> B3
+    B3["delete sales_/sample_ deck duplicates;<br/>one deck_builder"]
+  end
+
+  subgraph W3["Wave 3 — Slides (~1.5 wk)"]
+    C1["slide_spec.py loader (YAML in<br/>docs/slide_specs/*.yml)"] --> C2
+    C2["render_slide(spec, ctx.results)<br/>= action_title + callout + footer"] --> C3
+    C3["Author 9 section specs<br/>(dctr, rege, attrition, value,<br/>mailer, overview, insights, txn, exec)"] --> C4
+    C4["headline coverage → 100%<br/>(replace _noop with spec-driven titles)"]
+  end
+
+  subgraph W4["Wave 4 — CSM UX (~1 wk)"]
+    D1["Format tab → checklist pattern<br/>(parity with Generate)"]
+    D2["Surface run_scorecard.md +<br/>rates_audit.csv in completion card"]
+    D3["Slide-manifest editor in UI<br/>(Keep/Aux/Drop)"]
+    D4["Parquet chart cache + ODD warm-load<br/>(15–25 min → 10–15 min)"]
+  end
+
+  W1 -.numbers right.-> W3
+  W2 -.brand right.-> W3
+  W3 -.deck right.-> W4
+```
+
+The four waves can ship as four PRs against `claude/improve-csm-analysis-flow-7vGeU`; each one is independently valuable, but the order matters — beautiful slides built on wrong numbers are worse than ugly slides built on right ones.
+
+---
+
+## Wave 1 — Data accuracy (P0)
+
+Goal: the headline dollar figure on slide 1 and the CU‑vs‑PULSE benchmark on the insights slide are both defensible.
+
+### 1.1 Establish canonical denominators in `DataSubsets`
+
+File: `01_Analysis/00-Scripts/pipeline/context.py:64-74`, `01_Analysis/00-Scripts/pipeline/steps/subsets.py`
+
+`DataSubsets` already holds `open_accounts`, `eligible_data`, `eligible_personal`, `eligible_business`, `eligible_with_debit`, `last_12_months`. Add the missing "broad" bases the audit calls for so every rate has a labeled denominator:
+
+```python
+# context.py — DataSubsets additions
+open_personal: pd.DataFrame | None = None      # open ∩ Business?=No
+open_business: pd.DataFrame | None = None
+open_with_debit: pd.DataFrame | None = None    # open ∩ debit_mask
+canonical_dctr_base: pd.DataFrame | None = None  # alias → open_accounts
+canonical_rege_base: pd.DataFrame | None = None  # alias → open_personal
+```
+
+`step_subsets` builds them once. The "canonical" aliases are the choke point — every downstream module reads through the alias name so we can change the underlying base in one place if business intent shifts.
+
+### 1.2 Swap every DCTR / RegE call site
+
+22 known call sites in the audit's Denominator Reference Table. The pattern is mechanical:
+
+- `dctr/penetration.py:235,256-294,307-345` → `ed = ctx.subsets.canonical_dctr_base`
+- `dctr/branches.py:60-66,210-222,268-277,452,525-531` → same
+- `dctr/trends.py:55-86,300-314,609-617,691-705` → same
+- `dctr/overlays.py:60-368` → same
+- `dctr/funnel.py:74-94` → `te = len(canonical_dctr_base)`, rename the insights key `dctr_eligible` → `dctr_canonical` so headlines.py reads the right thing
+- `rege/_helpers.py:135-183` `reg_e_base` → `canonical_rege_base[debit_mask]` and change the audit's flagged slide titles to say "Reg E Opt-In among Personal Debit Holders" (the per-slide titles live in `docs/slide_specs/rege.md` and the headline generators in `headlines.py:399-411`)
+
+DCTR-2 ("Open vs Eligible") is the one slide that should keep both denominators visible — it's the methodology slide that explains the rest.
+
+### 1.3 Fix `insights/branch_scorecard.py`
+
+File: `01_Analysis/00-Scripts/analytics/insights/branch_scorecard.py:30-101`
+
+Today it reimplements DCTR/attrition/Reg E against raw `data`. Replace with reads from `ctx.results["dctr_9"]`, `ctx.results["attrition_4"]`, `ctx.results["reg_e_4"]` so the scorecard is identical to the detail slides. Also fix the alphabetical Reg E column pick at lines 83–86 — call `detect_reg_e_column(data)` from `rege/_helpers.py:119-132` (chronological).
+
+### 1.4 Standardize the "has debit" test
+
+`shared/helpers.py` (or a new `shared/debit.py`): one `has_debit(df, col)` that accepts strings + booleans + ints. Replace the four divergent definitions at `dctr/_helpers.py:42`, `insights/dormant.py:62`, `insights/branch_scorecard.py:71`, `mailer/reach.py:91`. Today a row with `True` reads as debit in one module and not-debit in another.
+
+### 1.5 Tighten silent‑drop behavior in `_safe` wrappers
+
+`dctr/penetration.py:37-50`, `rege/status.py:23-36`, `insights/_data.py:13-26`. When an analysis returns `success=False`, escalate to a top-level WARNING log AND record an `AnomalyFlag(level=WARN)` on the section in the run manifest (`pipeline/manifest.py:242` already provides `flag()`). Surfaces in `run_scorecard.md` and in the UI's completion card.
+
+### 1.6 Ship a per-run reconciliation artifact
+
+New file: `pipeline/steps/audit.py:write_rates_audit(ctx)` runs at the end of `step_generate`. Writes `rates_audit.csv` next to `run_manifest.json` with columns:
+
+```
+slide_id, metric, value, denominator_n, denominator_label, source_module
+```
+
+One row per rate the deck ships. A second run of the same client can diff vs the previous `rates_audit.csv` and fail CI if anything moved more than 1pp without an explanatory commit. Hook point: `01_Analysis/00-Scripts/pipeline/steps/generate.py:118`.
+
+### 1.7 Verify
+
+```bash
+cd 01_Analysis/00-Scripts && python -m pytest tests/ -q
+python run.py --month 2026.04 --csm James --client 1615      # ARS
+python run.py --month 2026.04 --csm James --client 1615 --product txn
+diff <(jq . prev_rates_audit.csv) <(jq . new_rates_audit.csv)
+```
+
+Spot‑check the headline number on DCTR-1, S1, S8, A11.1 against the notebook for one client before merging.
+
+---
+
+## Wave 2 — Brand & color authority
+
+Goal: one place defines the brand, every chart/Excel/PPTX/UI surface reads it.
+
+### 2.1 New `shared/brand.py` — single authority
+
+```python
+# shared/brand.py
+BRAND = {
+    "navy":          "#1A1A1A",   # README + UI header
+    "navy_soft":     "#2A2A2A",   # body text on dark
+    "accent":        "#F15D22",   # CSI orange
+    "accent_light":  "#fef0e8",
+    "accent_dark":   "#d14e1a",
+    "positive":      "#2A8B3E",
+    "negative":      "#C73E1D",
+    "warning":       "#F39C12",
+    "neutral":       "#8B95A2",
+    "muted":         "#B0B0B0",
+    "light_gray":    "#E8E8E8",
+    "bg":            "#FFFFFF",
+    "text":          "#222222",
+    "text_muted":    "#777777",
+}
+FONTS = {"title": "Montserrat", "body": "Montserrat", "mono": "Space Mono"}
+SIZES = {"action_title": 24, "subtitle": 16, "body": 12,
+         "callout_hero": 44, "callout_label": 14, "axis": 11, "footnote": 9}
+```
+
+### 2.2 Demote the existing color modules to aliases
+
+- `shared/charts.py` `COLORS` → re-export from `brand.BRAND`. Keep the dict literal API; just change the source.
+- `charts/style.py` legacy aliases (`PERSONAL`, `BUSINESS`, `HISTORICAL`, `TTM`, `TEAL`, etc.) → resolve to `brand.BRAND` values. ~65 analytics files keep working unchanged; they just get the right hexes.
+- `output/excel_formatter.py:15,24,26,102,113` and `shared/excel.py:19,56,101` → `brand.BRAND["navy"]`.
+- `output/deck_builder.py:259` `RGBColor(0x1B, 0x36, 0x5D)` → derived from `brand.BRAND["navy"]`.
+- `05_UI/index.html:18-26` CSS vars → keep the values (already correct); update `05_UI/UI-OVERVIEW.md:15` (says `#1A1A1A` while index.html actually shows `#00274C`) so it matches reality.
+
+### 2.3 Update governing docs
+
+- `SLIDE_DESIGN.md §5` color table → restate canonical CSI navy + accent, keep the muted/positive/negative grays.
+- `SLIDE_MAPPING.md "Color System"` → same.
+- `README.md:373` tech stack footer → keep as-is (already correct).
+- `docs/slide_specs/dctr.md` and `rege.md` → update color hex references in the action-title and callout sections.
+
+### 2.4 Collapse the duplicate deck builders
+
+- Keep `output/deck_builder.py` (the production path).
+- Delete `output/sample_deck_builder.py` (unused, confirmed by grep — no callers).
+- Move `output/sales_deck_builder.py` to `output/decks/sales.py` and have it import shared helpers from `deck_builder` rather than reimplementing `_add_fitted_picture` etc. `sales_charts.py` already pulls from `shared/charts.py`, so the brand swap in 2.1 carries it.
+
+### 2.5 Verify
+
+```bash
+grep -rE '#(1B365D|1E3D59|00274C|2E4057)' 01_Analysis/00-Scripts/ 05_UI/  # should be empty
+python -m pytest tests/ -q
+python run.py --month 2026.04 --csm James --client 1615
+```
+
+Eyeball the deck — every navy element is the same hex.
+
+---
+
+## Wave 3 — Beautiful slides (the design system, executed)
+
+Goal: every slide answers one question with an action title, one callout, one chart, and a footer band — per `SLIDE_DESIGN.md`. No more matplotlib-titled slides masquerading as consultant work.
+
+### 3.1 Spec format — YAML per slide
+
+Move `docs/slide_specs/*.md` to `docs/slide_specs/*.yml`. A spec is data, not prose:
+
+```yaml
+# docs/slide_specs/dctr.yml
+DCTR-MAIN-1:
+  layout: TWO_CONTENT
+  components: [A7.6a, DCTR-7]
+  action_title: "L12M DCTR of {l12m_rate:.0%} {direction} historical by {gap_pp:.0f}pp; {top_n} branches drive {contribution:.0%} of the gap"
+  inputs:
+    l12m_rate: ctx.results.dctr_3.insights.dctr
+    overall_rate: ctx.results.dctr_1.insights.overall_dctr
+    gap_pp: "{l12m_rate - overall_rate}*100"
+    direction: "trails if gap_pp<0 else beats"
+    top_n: 3
+    contribution: ctx.results.dctr_7.gap_contributors.share_top3
+  callout:
+    hero: "${delta_revenue:,.1f}M"
+    sub: "annual debit interchange uplift"
+    tertiary: "Closing the gap at {b1}, {b2}, {b3} to portfolio-median DCTR"
+  footer:
+    source: "Source: {client_name} ODD, {month} | N = {eligible_count:,}"
+```
+
+The DCTR and Reg E spec docs are already drafted in markdown — converting them is a translation task, not new design.
+
+### 3.2 New `output/slide_spec.py` — load + render
+
+Two functions:
+
+```python
+def load_specs(section: str) -> dict[str, SlideSpec]:
+    """Parse docs/slide_specs/<section>.yml into typed SlideSpec objects."""
+
+def render_spec(spec: SlideSpec, ctx_results: dict, client: ClientInfo) -> SlideContent:
+    """Resolve inputs, format the action title, build the callout, return SlideContent."""
+```
+
+Wire `render_spec` into `deck_builder._result_to_slide` (line 1547) — when a spec exists for `slide_id`, render from it; otherwise fall back to today's behavior. Zero-risk rollout: turn on slide-by-slide.
+
+### 3.3 Author 9 section specs
+
+The structure from `dctr.md` is the template. Per section, the deliverable is a `.yml` file + ~3 main-deck slides + an appendix routing block. Sized realistically:
+
+| Section | Main slides | Notes |
+|---|---|---|
+| `overview.yml` | 1 (Account Composition KPI hero) | already drafted as A1 |
+| `dctr.yml` | 3 | already drafted; convert markdown → YAML |
+| `rege.yml` | 2 | already drafted; relabel for narrow base |
+| `attrition.yml` | 2 (A9.1 rate, A9.11 revenue impact) | |
+| `value.yml` | 1 (A11.1 hero + waterfall) | |
+| `mailer.yml` | 2 (most recent month + aggregate) | |
+| `insights.yml` | 3 (S1 revenue gap, S6 opportunity map, S8 action plan) | |
+| `txn_exec.yml` | 1 (executive scorecard) | |
+| `competition.yml` | 2 (threat quadrant + wallet share) | |
+
+That's ~17 main-deck slides per deck instead of today's 100+ — closer to the McKinsey 25-max rule. Everything else routes to the appendix via the existing `SLIDE_MANIFEST.xlsx` (`A` marker → aux deck, already wired in `output/manifest.py`).
+
+### 3.4 Bring the callout box, footer band, and action title into `deck_builder`
+
+Today's `_build_screenshot_slide` (line 503) just slaps a fitted PNG onto a slide with no title region. Replace with `_build_action_slide`:
+
+- Action title block at top: 24pt bold navy, 2-line max, left-aligned.
+- Chart region in the middle.
+- Callout box: bottom-overlay text box, accent border, hero number 44pt bold accent, two lines of subtext.
+- Footer band: 9pt italic source line + 8pt confidentiality line.
+
+Use the existing `chart_annotations.py` callout patterns as the starting point (it already draws boxed callouts on matplotlib axes).
+
+### 3.5 100% headline coverage
+
+`output/headlines.py:550-637` has 60+ entries; many are `_noop`. For every slide the spec covers, replace `_noop` with a spec-driven generator that reads the action_title template. Where a slide has no spec (the appendix slides), keep the analytics title — that's fine for the appendix.
+
+### 3.6 Slide-side fixes called out in Wave 1 audit (the chart-level work)
+
+These are documented as Module-level work required in `docs/slide_specs/dctr.md:194-204` and across `docs/deck/wave1-implementation.md`:
+
+- `dctr/trends.py` (A7.6a): add muted-gray volume columns behind the teal rate line; add dashed historical reference line.
+- `dctr/branches.py` (DCTR-7): rebuild as vertical combo with branches on X, historical + L12M lines, three focus branches highlighted.
+- `dctr/funnel.py`: add `biggest_drop_stage` + `drop_pct` to insights dict.
+- `value/analysis.py` (A11.1): expose `waterfall_stages` list as structured data on `ctx.results["value_1"]` for the waterfall renderer.
+- Drop zero-volume categories before plotting (already an `SLIDE_DESIGN.md §6.2` rule, not enforced today).
+
+### 3.7 Verify
+
+```bash
+python -m pytest tests/ -q
+python run.py --month 2026.04 --csm James --client 1615 --product combined
+# Open the deck; check that every main-deck slide has:
+#   1. Action-title sentence with a number in it
+#   2. Callout box with hero number visible at distance
+#   3. Footer band with source + confidentiality
+#   4. Same brand colors as Wave 2
+```
+
+Run two adjacent clients side-by-side and confirm the action titles are different sentences with different numbers — if they're the same, the spec is mis-bound.
+
+---
+
+## Wave 4 — CSM experience (speed, observability, control)
+
+Goal: shave runtime, surface the diagnostics that already exist but the operator never sees, give them deck control without leaving the UI.
+
+### 4.1 Format tab parity with Generate
+
+`05_UI/UI-OVERVIEW.md:58` calls this out as a known follow-up. Replicate the 5-stage checklist + completion-card pattern from Generate (`#gRunView`, `#gDoneView`) into Format. The backend hooks are already there (`/api/format` returns a `run_id`, `/api/run/{id}` streams) — this is frontend-only work in `index.html` against the same `_classifyStage` parser.
+
+### 4.2 Surface the scorecard and rates audit in the UI
+
+After a run completes, fetch `run_scorecard.md` + `rates_audit.csv` and render:
+
+- A "Run Quality" tab in the completion card showing the manifest verdict ("Ship" / "Investigate before shipping").
+- A collapsible "Anomaly Flags" list (already produced by the SectionRecorder API).
+- A diff badge: "↑ 3 rates moved >1pp vs last run" with click-through to the rates_audit.
+
+Backend: extend `/api/outputs/{csm}/{month}/{client_id}` to include `scorecard_url` and `rates_audit_url`. Frontend: new section in `#gDoneView` near the warnings panel.
+
+### 4.3 Slide-manifest editor in the UI
+
+Today CSMs edit `SLIDE_MANIFEST.xlsx` in Excel — a sharp-edged workflow. Add a "Deck Shape" panel on the Results tab:
+
+- For the currently selected client/period, load `run_manifest.json` (lists every slide ID + title) + the current `SLIDE_MANIFEST.xlsx` decisions.
+- Render a sortable grid: slide_id, title, current decision (Y/A/N/blank), section.
+- Allow toggling Y → A → N → blank inline.
+- "Save" writes back to `SLIDE_MANIFEST.xlsx` via a new `POST /api/manifest` endpoint.
+- "Rebuild deck" button next to it kicks off a deck-only rebuild (no re-analysis) using the new decisions.
+
+The data path is already there — `output/manifest.py` reads, the deck builder applies. The UI just needs an editor and a write endpoint.
+
+### 4.4 Speed: cache the ODD copy and the chart renders
+
+Two known bottlenecks:
+
+- `pipeline/steps/load.py:178-198` already copies the .xlsx to a temp file before reading (the network‑drive openpyxl latency fix). Cache the temp copy keyed by source mtime + size so two runs of the same client in one session skip the copy.
+- Chart PNGs are re-rendered on every run even when the slide content is identical. Add a content hash (input DataFrame fingerprint + style hash) at `chart_figure` save time; if the PNG with the same hash already exists in `charts_dir`, reuse it. Net effect on a 25-minute run with a hot cache: closer to 10–12 minutes. The existing `MAX_CHART_HEIGHT` and `save_chart_png` paths in `shared/charts.py:36` are the natural hook.
+
+### 4.5 Verify
+
+Run a second-time `python run.py --month 2026.04 --csm James --client 1615` and confirm:
+
+- Format tab now shows the checklist + completion card (parity with Generate).
+- The completion card shows scorecard verdict + rates-audit diff.
+- Editing a slide's Keep? in the new UI panel, hitting Rebuild deck, produces a new PPTX with that slide removed — without re-running analysis.
+- Second-run wall time is materially lower than first run (cache hits in the log).
+
+---
+
+## Files this plan touches (most important)
+
+| Area | Files |
+|---|---|
+| Data accuracy | `pipeline/context.py`, `pipeline/steps/subsets.py`, `analytics/dctr/*.py`, `analytics/rege/*.py`, `analytics/value/analysis.py`, `analytics/insights/branch_scorecard.py`, `analytics/insights/_data.py`, `analytics/insights/synthesis.py`, `analytics/insights/conclusions.py`, `analytics/insights/effectiveness.py`, new `pipeline/steps/audit.py`, new `shared/debit.py` |
+| Brand | new `shared/brand.py`, `shared/charts.py`, `charts/style.py`, `output/excel_formatter.py`, `shared/excel.py`, `output/deck_builder.py`, `output/sales_deck_builder.py` (move), delete `output/sample_deck_builder.py`, `SLIDE_DESIGN.md`, `SLIDE_MAPPING.md`, `05_UI/UI-OVERVIEW.md` |
+| Slides | new `output/slide_spec.py`, new `docs/slide_specs/*.yml` (9 files), `output/deck_builder.py` (`_build_action_slide` + `_result_to_slide`), `output/headlines.py`, `analytics/dctr/trends.py`, `analytics/dctr/branches.py`, `analytics/dctr/funnel.py`, `analytics/value/analysis.py` |
+| CSM UX | `05_UI/index.html` (Format checklist, scorecard panel, manifest editor), `05_UI/app.py` (new `/api/manifest`, extended `/api/outputs`), `pipeline/steps/load.py` (ODD cache), `shared/charts.py` (chart-render cache) |
+
+---
+
+## What this plan does not do
+
+- Does not redesign every one of the 339 TXN slides — Wave 3 covers the ~17 main-deck slides per the SLIDE_DESIGN main-deck-25-max rule; everything else stays in the appendix where the existing styling is acceptable.
+- Does not address `competition` section's known axis-scaling bugs (`12_bubble_chart`, `13_threat_quadrant`, `26_spend_scatter`, `28_spend_vs_frequency`) — those are tracked in `docs/deck/wave1-implementation.md` as Wave 4 and need a separate per-chart pass.
+- Does not change Step 1 formatting (`00_Formatting/run.py`) — out of scope; the audit found no issues there.
+- Does not add a CI pipeline. The `rates_audit.csv` diff is a foundation a future CI can use; wiring it to GitHub Actions is a follow-up.
+- Does not rename the operator-facing modules (e.g., `ars`, `txn`, `dep`) — name churn for no operator benefit.

--- a/docs/plans/2026-06-06-velocity-pipeline-reconciled.md
+++ b/docs/plans/2026-06-06-velocity-pipeline-reconciled.md
@@ -1,0 +1,393 @@
+# Velocity Pipeline — Accuracy, Brand, Slides, CSM UX (reconciled)
+
+**Status:** Proposal · supersedes `2026-06-04-velocity-pipeline-accuracy-and-design.md` (remote ultraplan output)
+**Branches off:** `main`
+**Anchor docs:** `CLAUDE.md` (UI-first rule) · memory `project_denominator_framework.md` (4-layer law) · `SLIDE_DESIGN.md`
+
+---
+
+## Why this supersedes the ultraplan output
+
+The remote ultraplan was working off `docs/audits/2026-04-17-data-quality-audit.md` (49 days old). Two of its three diagnoses are stale or inverted:
+
+| Ultraplan claim | Current code reality |
+|---|---|
+| "Reg E denominator is `eligible_personal ∩ has_debit` — fix by switching to `open_personal`" | `analytics/rege/_helpers.py:135-183` already reads `eligible_personal` with an explicit comment citing the 4-layer framework. No `∩ has_debit` filter remains in the denominator. **Already fixed.** |
+| "`insights/branch_scorecard.py` reimplements rates against raw `ctx.data` — fix by reading `ctx.results`" | `branch_scorecard.py:46-53` already has a primary path that pulls from `ctx.results`; `_recompute_from_raw` at line 119 is a documented *fallback* that uses `eligible_data` (not raw `ctx.data`). **Already partially fixed.** Remaining work: make the fallback observable (log + manifest WARN flag when it fires) so we know if it's silently masking missing upstream results. |
+| "Pipeline reports ~30% DCTR vs notebook's ~80% — fix by broadening the denominator to `open_accounts`" | `pipeline/steps/subsets.py:97-99` literally comments *"DCTR goes from 80% to 30% if closed are included"*. The 4-layer law (memory `project_denominator_framework.md`) says **Eligible is the primary default; Open is reference framing only**. The pipeline's 30% is correct. The notebook's 80% is the Open-based reference. The fix is **labeling**, not math. |
+
+What survives from the ultraplan:
+- The brand/color authority problem (Wave 2) — independent of the math, real, ~65 files touched today.
+- The slide design system gap (Wave 3) — ~40% headlines are `_noop`; only 2 of 9 sections have specs; three deck-builder files where one belongs.
+- The CSM UX gaps (Wave 4) — Format tab has no checklist parity, `run_scorecard.md` is written but never surfaced, slide manifest is edited in Excel, no caching of the ODD temp-copy or chart PNGs.
+- The `rates_audit.csv` per-run artifact (Wave 1) — but **re-purposed** to enforce the 4-layer law (every rate must label exactly one of the four denominators), not to chase notebook parity.
+
+---
+
+## Shape of the change
+
+```mermaid
+flowchart TB
+  subgraph W1["W1 — Law enforcement (~3 days)"]
+    A1["rates_audit.csv per run:<br/>slide_id, metric, value, denom_label,<br/>denom_n, source_module"] --> A2
+    A2["Validator: denom_label must be one of<br/>Eligible / Eligible Personal /<br/>Eligible Business / Open"] --> A3
+    A3["branch_scorecard fallback fires<br/>→ manifest WARN flag"]
+    A4["Single has_debit(df) helper<br/>(consolidate 4 divergent definitions)"]
+  end
+
+  subgraph W2["W2 — Brand authority (~3 days)"]
+    B1["shared/brand.py = single source<br/>(CSI navy #1A1A1A + orange #F15D22)"] --> B2
+    B2["shared/charts.py + charts/style.py +<br/>excel_formatter aliases → brand.py"] --> B3
+    B3["Delete sample_deck_builder.py;<br/>move sales_deck_builder under output/decks/"]
+  end
+
+  subgraph W3["W3 — Slide design system (~1.5 wk)"]
+    C1["output/slide_spec.py<br/>(YAML loader + renderer)"] --> C2
+    C2["docs/slide_specs/*.yml × 9 sections"] --> C3
+    C3["_build_action_slide:<br/>action title + chart + callout + footer"] --> C4
+    C4["Replace _noop headlines<br/>with spec-driven generators"]
+  end
+
+  subgraph W4["W4 — CSM experience (~1 wk)"]
+    D1["Format tab → checklist + completion card<br/>(parity with Generate)"]
+    D2["Surface run_scorecard.md +<br/>rates_audit.csv + denom-law violations"]
+    D3["Slide-manifest editor in UI<br/>(Keep/Aux/Drop)"]
+    D4["Caches: ODD temp-copy + chart PNG<br/>by content hash"]
+  end
+
+  W1 -.label law.-> W3
+  W2 -.brand.-> W3
+  W3 -.deck.-> W4
+```
+
+Four PRs against `main`, one per wave, in order. Each one is independently shippable.
+
+---
+
+## Wave 1 — Law enforcement (NOT denominator surgery) — ~3 days
+
+### What this is not
+
+This wave does **not** swap denominators in DCTR, Value, Insights, or anywhere else. The 4-layer framework is already encoded in `subsets.py`. The numbers the pipeline produces today are correct per the law.
+
+### What this is
+
+Make the law machine-checkable, so future drift gets caught. Plus two genuine bugs the ultraplan correctly identified that survive the stale audit.
+
+### 1.1 Per-run `rates_audit.csv`
+
+New file: `01_Analysis/00-Scripts/pipeline/steps/audit.py`. Runs at the end of `step_generate` (hook at `pipeline/steps/generate.py:118`). Writes `rates_audit.csv` next to `run_manifest.json`:
+
+```
+slide_id, metric, value, denominator_label, denominator_n, source_module, framework_compliant
+```
+
+Every rate the deck ships gets one row. `denominator_label` must be exactly one of:
+
+- `Eligible`
+- `Eligible Personal`
+- `Eligible Business`
+- `Open` (reference framing only — flagged if used as primary denominator)
+
+`framework_compliant` is the boolean result of the validator (see 1.2).
+
+### 1.2 Denominator-law validator
+
+`pipeline/steps/audit.py:validate_against_law()` walks the rates_audit and:
+
+- Rejects any `denominator_label` not in the four-layer set.
+- Flags any row where `denominator_label == "Open"` and the slide_id is not on the explicit reference-framing allowlist (currently: `DCTR-2` "Open vs Eligible" methodology slide only).
+- Writes violations as `AnomalyFlag(level=WARN)` on the run manifest via `manifest.flag()` (`pipeline/manifest.py:242` already provides the API).
+- Returns a count surfaced in `run_scorecard.md` as "Denominator law: N violations" (zero = ship, ≥1 = investigate).
+
+Each analytics module reports its rate's denominator label by stamping it in its `AnalysisResult.insights` dict — a new contract field `denominator_label`. Modules without the field emit `framework_compliant=False` until they're updated; this is the lever for incremental rollout.
+
+### 1.3 `branch_scorecard` fallback observability
+
+`analytics/insights/branch_scorecard.py:53`. When `_recompute_from_raw` fires (because upstream `ctx.results` are missing), today it silently returns. Add:
+
+- `logger.warning("branch_scorecard fell back to eligible_data recompute (upstream results missing)")`
+- `ctx.manifest.flag(section="insights", level="WARN", message="branch_scorecard fallback fired")` if `ctx.manifest` is not None.
+
+Three lines. Doesn't change the math — makes the silent path noisy.
+
+### 1.4 Standardize `has_debit`
+
+New file: `01_Analysis/00-Scripts/shared/debit.py`:
+
+```python
+def has_debit(df: pd.DataFrame, col: str = "Debit Card") -> pd.Series:
+    """Truthy mask covering strings ('Y','Yes','True'), booleans, and ints."""
+```
+
+Replace the four divergent definitions at:
+- `analytics/dctr/_helpers.py:42`
+- `analytics/insights/dormant.py:62`
+- `analytics/insights/branch_scorecard.py:71`
+- `analytics/mailer/reach.py:91`
+
+Verify: run a representative client; the debit-holder count should be identical across all four modules in `run_manifest.json`.
+
+### 1.5 Tighten `_safe` silent-drop wrappers
+
+`analytics/dctr/penetration.py:37-50`, `analytics/rege/status.py:23-36`, `analytics/insights/_data.py:13-26`. On `success=False`, escalate to top-level WARN and stamp `AnomalyFlag(level=WARN)`. Same `manifest.flag()` API.
+
+### 1.6 Verify
+
+```bash
+cd 01_Analysis/00-Scripts && python -m pytest tests/ -q
+python run.py --month 2026.04 --csm James --client 1615
+cat 01_Analysis/01_Completed_Analysis/James*/2026.04/1615/rates_audit.csv
+cat 01_Analysis/01_Completed_Analysis/James*/2026.04/1615/run_manifest.json | jq '.anomaly_flags'
+```
+
+Expectations:
+- `rates_audit.csv` exists, one row per shipped rate, `denominator_label` populated.
+- First-run violation count > 0 (most modules don't stamp `denominator_label` yet — that's the punch list for follow-up commits, not a Wave 1 blocker).
+- `branch_scorecard fallback fired` shows up in anomaly flags when relevant; absent when not.
+- `has_debit` consolidated count identical across the four modules.
+
+---
+
+## Wave 2 — Brand authority — ~3 days
+
+Goal: one file defines the brand, every chart / Excel / PPTX / UI surface reads from it.
+
+### 2.1 New `01_Analysis/00-Scripts/shared/brand.py`
+
+```python
+BRAND = {
+    "navy":          "#1A1A1A",   # canonical (README + UI header)
+    "navy_soft":     "#2A2A2A",
+    "accent":        "#F15D22",   # CSI orange
+    "accent_light":  "#fef0e8",
+    "accent_dark":   "#d14e1a",
+    "positive":      "#2A8B3E",
+    "negative":      "#C73E1D",
+    "warning":       "#F39C12",
+    "neutral":       "#8B95A2",
+    "muted":         "#B0B0B0",
+    "light_gray":    "#E8E8E8",
+    "bg":            "#FFFFFF",
+    "text":          "#222222",
+    "text_muted":    "#777777",
+}
+FONTS = {"title": "Montserrat", "body": "Montserrat", "mono": "Space Mono"}
+SIZES = {
+    "action_title": 24, "subtitle": 16, "body": 12,
+    "callout_hero": 44, "callout_label": 14, "axis": 11, "footnote": 9,
+}
+```
+
+### 2.2 Demote existing color modules to aliases
+
+- `shared/charts.py` `COLORS` → re-export from `brand.BRAND`. Dict literal API unchanged.
+- `charts/style.py` legacy semantic aliases (`PERSONAL`, `BUSINESS`, `HISTORICAL`, `TTM`, `TEAL`, etc.) → resolve to `brand.BRAND` values. ~65 analytics files unchanged; they just get the right hexes.
+- `output/excel_formatter.py:15,24,26,102,113` and `shared/excel.py:19,56,101` → `brand.BRAND["navy"]`.
+- `output/deck_builder.py:259` `RGBColor(0x1B, 0x36, 0x5D)` → derived from `brand.BRAND["navy"]`.
+- `05_UI/index.html:18-26` CSS vars — verify against actual file (UI memo says `#1A1A1A`, but actual current value may differ). Update `05_UI/UI-OVERVIEW.md:15` so docs match reality.
+
+### 2.3 Update governing docs
+
+- `SLIDE_DESIGN.md §5` color table → restate canonical CSI navy + accent.
+- `SLIDE_MAPPING.md "Color System"` section → same.
+- `docs/slide_specs/dctr.md` and `rege.md` color references → align.
+
+### 2.4 Collapse duplicate deck builders
+
+- Keep `01_Analysis/00-Scripts/output/deck_builder.py` (production path).
+- Delete `output/sample_deck_builder.py` (verify zero callers via `grep -rn sample_deck_builder` before delete).
+- Move `output/sales_deck_builder.py` → `output/decks/sales.py`; import shared helpers (`_add_fitted_picture` etc.) from `deck_builder` rather than reimplementing.
+
+### 2.5 Verify
+
+```bash
+grep -rE '#(1B365D|1E3D59|00274C|2E4057)' 01_Analysis/00-Scripts/ 05_UI/ 02_Presentations/
+# Expected: empty.
+grep -rn 'sample_deck_builder\|sales_deck_builder' 01_Analysis/
+# Expected: only the new output/decks/sales.py path.
+python -m pytest tests/ -q
+python run.py --month 2026.04 --csm James --client 1615
+```
+
+Open the deck; every navy element should be the same hex. Open the PPTX in `02_Presentations/James*/2026.04/1615/` and eyeball.
+
+---
+
+## Wave 3 — Slide design system executed — ~1.5 wk
+
+Goal: every main-deck slide follows `SLIDE_DESIGN.md` anatomy — action title (with a number in it), one chart, one callout, footer band. ~17 main-deck slides per the McKinsey-25 rule; everything else routes to the appendix via the existing `SLIDE_MANIFEST.xlsx` `A`-marker pathway.
+
+### 3.1 YAML spec format
+
+Move `docs/slide_specs/*.md` to `docs/slide_specs/*.yml`. Spec is data, not prose:
+
+```yaml
+DCTR-MAIN-1:
+  layout: TWO_CONTENT
+  components: [A7.6a, DCTR-7]
+  action_title: "L12M DCTR of {l12m_rate:.0%} {direction} historical by {gap_pp:.0f}pp; {top_n} branches drive {contribution:.0%} of the gap"
+  inputs:
+    l12m_rate: ctx.results.dctr_3.insights.dctr
+    overall_rate: ctx.results.dctr_1.insights.overall_dctr
+    gap_pp: "{l12m_rate - overall_rate}*100"
+    direction: "trails if gap_pp<0 else beats"
+    top_n: 3
+    contribution: ctx.results.dctr_7.gap_contributors.share_top3
+  denominator_label: Eligible      # <-- ties Wave 1 law to the slide
+  callout:
+    hero: "${delta_revenue:,.1f}M"
+    sub: "annual debit interchange uplift"
+    tertiary: "Closing the gap at {b1}, {b2}, {b3} to portfolio-median DCTR"
+  footer:
+    source: "Source: {client_name} ODD, {month} | N = {eligible_count:,}"
+```
+
+The `denominator_label` field links W1 to W3: the validator can confirm that the spec's declared denominator matches what the source module stamped.
+
+### 3.2 `output/slide_spec.py` — loader + renderer
+
+```python
+def load_specs(section: str) -> dict[str, SlideSpec]:
+    """Parse docs/slide_specs/<section>.yml into typed SlideSpec objects."""
+
+def render_spec(spec: SlideSpec, ctx_results: dict, client: ClientInfo) -> SlideContent:
+    """Resolve inputs, format the action title, build the callout, return SlideContent."""
+```
+
+Wire into `deck_builder._result_to_slide` (line 1547). When a spec exists for `slide_id`, render from it; otherwise fall back to today's behavior. Zero-risk rollout: slide-by-slide.
+
+### 3.3 Author 9 section specs
+
+| Section | Main slides | Status |
+|---|---|---|
+| `overview.yml` | 1 | already drafted as A1 |
+| `dctr.yml` | 3 | already drafted in `dctr.md`; convert MD → YAML |
+| `rege.yml` | 2 | already drafted; relabel for `Eligible Personal` |
+| `attrition.yml` | 2 (A9.1 rate, A9.11 revenue impact) | new |
+| `value.yml` | 1 (A11.1 hero + waterfall) | new |
+| `mailer.yml` | 2 (most recent month + aggregate) | new |
+| `insights.yml` | 3 (S1 revenue gap, S6 opportunity map, S8 action plan) | new |
+| `txn_exec.yml` | 1 (executive scorecard) | new |
+| `competition.yml` | 2 (threat quadrant + wallet share) | new |
+
+Total: ~17 main-deck slides. Everything else is `A`-routed to `*_aux_deck.pptx` via the existing manifest pathway in `output/manifest.py`.
+
+### 3.4 `_build_action_slide` in `deck_builder`
+
+Replace `_build_screenshot_slide` (currently around line 503 — verify in current state). Components, top-down:
+- Action title block: 24pt bold navy, 2-line max, left-aligned.
+- Chart region: fitted PNG.
+- Callout box: bottom-overlay, accent border, hero number 44pt bold accent, two lines of subtext.
+- Footer band: 9pt italic source line + 8pt confidentiality.
+
+Reuse `chart_annotations.py` callout patterns for the callout box geometry.
+
+### 3.5 Headline coverage
+
+`output/headlines.py:550-637` has 60+ entries, many `_noop`. For every slide the spec covers, replace `_noop` with a spec-driven generator (the spec's `action_title` template). Slides without specs stay on analytics titles — fine for the appendix.
+
+### 3.6 Chart-level work called out by the existing spec docs
+
+These are the genuine remaining items from `docs/slide_specs/dctr.md:194-204` and `docs/deck/wave1-implementation.md`:
+
+- `dctr/trends.py` (A7.6a): muted-gray volume columns behind teal rate line; dashed historical reference line.
+- `dctr/branches.py` (DCTR-7): vertical combo, historical + L12M lines, three focus branches highlighted.
+- `dctr/funnel.py`: add `biggest_drop_stage` + `drop_pct` to insights.
+- `value/analysis.py` (A11.1): expose `waterfall_stages` list as structured data on `ctx.results["value_1"]`.
+- Drop zero-volume categories before plotting (`SLIDE_DESIGN.md §6.2` rule, not enforced today).
+
+### 3.7 Verify
+
+```bash
+python -m pytest tests/ -q
+python run.py --month 2026.04 --csm James --client 1615 --product combined
+# Open the deck. Every main-deck slide should have:
+#   1. Action-title sentence with a number in it
+#   2. Callout box with a hero number visible at distance
+#   3. Footer band with source + confidentiality
+#   4. Brand colors from Wave 2
+```
+
+Sanity check: run two adjacent clients side-by-side. The action titles should be different sentences with different numbers. If they're the same, the spec is mis-bound to `ctx.results`.
+
+---
+
+## Wave 4 — CSM experience — ~1 wk
+
+Goal: shave runtime; surface diagnostics that exist but the operator never sees; give them deck control without leaving the UI.
+
+Per `CLAUDE.md` UI-first rule: every new capability ships as a button/panel/tab in `05_UI/index.html` backed by an endpoint in `05_UI/app.py`. No CLI-only additions.
+
+### 4.1 Format tab → checklist parity with Generate
+
+`05_UI/UI-OVERVIEW.md:58` calls this out as a known follow-up. Replicate the 5-stage checklist + completion-card pattern from Generate (`#gRunView`, `#gDoneView`) into Format. Backend already returns a `run_id`; this is frontend work against the same `_classifyStage` parser.
+
+### 4.2 Surface scorecard + rates audit + law violations
+
+After a run completes, fetch `run_scorecard.md`, `rates_audit.csv`, and the anomaly flags from `run_manifest.json`. Render in the completion card:
+
+- "Run Quality" panel: manifest verdict ("Ship" / "Investigate before shipping").
+- "Anomaly Flags" collapsible: `branch_scorecard fallback fired`, `_safe wrappers returned success=False`, etc.
+- "Denominator Law" panel: violation count + click-through to `rates_audit.csv` filtered to non-compliant rows.
+
+Backend: extend `GET /api/outputs/{csm}/{month}/{client_id}` to include `scorecard_url`, `rates_audit_url`, `flag_count`, `denom_violation_count`. Frontend: new section in `#gDoneView`.
+
+### 4.3 Slide-manifest editor in the UI
+
+Today CSMs edit `SLIDE_MANIFEST.xlsx` in Excel. Add a "Deck Shape" panel on the Results tab:
+
+- For the selected client/period, load `run_manifest.json` (slide IDs + titles) + current `SLIDE_MANIFEST.xlsx` decisions.
+- Sortable grid: `slide_id, title, current_decision (Y/A/N/blank), section`.
+- Toggle inline `Y → A → N → blank`.
+- "Save" → `POST /api/manifest` writes back to `SLIDE_MANIFEST.xlsx`.
+- "Rebuild deck" → deck-only rebuild (no re-analysis) using new decisions.
+
+Data path is already there; this is editor + write endpoint.
+
+### 4.4 Caching for speed
+
+Two known bottlenecks:
+
+- **ODD temp-copy cache.** `pipeline/steps/load.py:178-198` copies the `.xlsx` to a temp file before reading (network-drive openpyxl latency workaround). Cache the temp copy keyed by `(source_path, mtime, size)`. Second run of the same client in one session skips the copy.
+- **Chart PNG cache.** Re-rendered every run. Add a content hash (input DataFrame fingerprint + style hash) at `chart_figure` save time. If the PNG with the same hash exists in `charts_dir`, reuse it. Hook: `shared/charts.py:36` `save_chart_png`.
+
+Expected effect on a hot second run: ~25 min → ~10–15 min. Cold runs unchanged.
+
+### 4.5 Verify
+
+Run a second-time `python run.py --month 2026.04 --csm James --client 1615` and confirm:
+- Format tab shows the checklist + completion card.
+- Completion card shows scorecard verdict, anomaly flags, denominator-law violation count.
+- Editing a slide's `Keep?` in the new UI panel + Rebuild deck produces a new PPTX with that slide removed — no re-analysis.
+- Second-run wall time is materially lower than first run; cache hit lines visible in the log.
+
+---
+
+## Files this plan touches
+
+| Wave | Files |
+|---|---|
+| W1 | new `pipeline/steps/audit.py`, new `shared/debit.py`, `pipeline/steps/generate.py`, `analytics/insights/branch_scorecard.py`, `analytics/dctr/_helpers.py`, `analytics/insights/dormant.py`, `analytics/mailer/reach.py`, `analytics/dctr/penetration.py`, `analytics/rege/status.py`, `analytics/insights/_data.py`, each `AnalysisResult` insights producer (stamp `denominator_label`) |
+| W2 | new `shared/brand.py`, `shared/charts.py`, `charts/style.py`, `output/excel_formatter.py`, `shared/excel.py`, `output/deck_builder.py`, `output/sales_deck_builder.py` (move), delete `output/sample_deck_builder.py`, `SLIDE_DESIGN.md`, `SLIDE_MAPPING.md`, `05_UI/UI-OVERVIEW.md` |
+| W3 | new `output/slide_spec.py`, new `docs/slide_specs/*.yml` (9 files), `output/deck_builder.py` (`_build_action_slide` + `_result_to_slide`), `output/headlines.py`, `analytics/dctr/trends.py`, `analytics/dctr/branches.py`, `analytics/dctr/funnel.py`, `analytics/value/analysis.py` |
+| W4 | `05_UI/index.html`, `05_UI/app.py` (new `/api/manifest`, extended `/api/outputs`), `pipeline/steps/load.py` (ODD cache), `shared/charts.py` (chart cache) |
+
+---
+
+## Explicit non-goals
+
+- Does **not** broaden any denominator. The 4-layer law stands; W1 enforces it, doesn't relitigate it.
+- Does **not** redesign all 339 TXN slides. W3 covers ~17 main-deck slides per the McKinsey-25 rule; everything else stays in the appendix.
+- Does **not** address competition section axis-scaling bugs (`12_bubble_chart`, `13_threat_quadrant`, `26_spend_scatter`, `28_spend_vs_frequency`) — separate per-chart pass.
+- Does **not** change Step 1 formatting (`00_Formatting/run.py`). Out of scope.
+- Does **not** wire CI. `rates_audit.csv` is the foundation for future CI; GitHub Actions hookup is a follow-up.
+- Does **not** rename operator-facing modules (`ars`, `txn`, `dep`). Name churn for no operator benefit.
+
+---
+
+## Open questions before W1 starts
+
+1. **Slide-spec denominator_label as soft or hard contract?** Soft = warn-only on mismatch with module stamp; hard = block deck render. Recommend soft for the first three runs, then promote to hard once the per-module stamps are populated.
+2. **Where does `rates_audit.csv` live in the UI?** Recommend: completion card "Run Quality" panel only (not its own tab) — keeps the UI focused on the loop the CSM already knows.
+3. **Reference-framing allowlist for `Open` denominator.** Currently the only slide the framework permits is `DCTR-2` "Open vs Eligible." Verify no other slide legitimately needs Open before W1 ships the validator.


### PR DESCRIPTION
## Summary

Wave 1 of the reconciled 4-wave plan (`docs/plans/2026-06-06-velocity-pipeline-reconciled.md`). Makes the 4-layer denominator framework (LAW per `project_denominator_framework.md`) machine-checkable.

* Single canonical `shared/debit.py` consolidating 4 divergent `has_debit` definitions
* New `pipeline/steps/audit.py` emits `rates_audit.csv` per run + validates every rate against `Eligible / Eligible Personal / Eligible Business / Open`
* `Open` only legal as primary denominator on `dctr_2` (Open vs Eligible methodology slide); flagged anywhere else
* `branch_scorecard` switched from raw `ctx.data` to `ctx.subsets.eligible_data` to match the detail slides; fallback path is now noisy (WARN + manifest flag)
* `_safe` wrappers (dctr penetration, rege status, insights data) escalate failures to `AnomalyFlag(WARN)` instead of silently returning `success=False`

## What this does **not** do

- Does **not** broaden any denominator. The 4-layer law stands; W1 enforces it, doesn't relitigate it.
- Does **not** require every module to stamp `denominator_label` up front — defaults come from a per-slide-prefix registry, modules override by stamping `denominator_label` on `AnalysisResult`.
- The remote ultraplan output had recommended swapping DCTR to an `open_accounts` denominator (~80%); that inverts your law. The pipeline's ~30% Eligible-based DCTR is correct.

## Test plan

- [x] `pytest tests/` — 66/66 passing (10 new in `test_audit.py`)
- [ ] On work PC: run one ARS client, confirm `rates_audit.csv` lands next to `run_manifest.json`
- [ ] Confirm `run_scorecard.md` surfaces any denominator-law violations as anomaly flags
- [ ] Confirm `branch_scorecard` fallback flag fires when run on a client whose `eligible_data` subset is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)