### PR TITLE
feat(w3): YAML slide-spec system + spec-driven action titles

### DIFF
--- a/01_Analysis/00-Scripts/output/deck_builder.py
+++ b/01_Analysis/00-Scripts/output/deck_builder.py
@@ -515,6 +515,10 @@ class DeckBuilder:
         Charts already have titles rendered by matplotlib, so we skip
         the slide title placeholder to avoid duplication. The chart
         fills most of the slide with a small margin.
+
+        Wave 3 follow-up: when SlideContent carries callout_hero / footer_source
+        (populated by output/slide_spec.render_spec), overlay the callout box
+        and footer band per SLIDE_DESIGN.md anatomy.
         """
         # Remove all placeholders -- chart image IS the content
         for ph in slide.placeholders:
@@ -523,19 +527,140 @@ class DeckBuilder:
             except Exception:
                 pass
 
-        # Position chart to fill the slide with small margins
+        has_callout = bool(content.callout_hero or content.callout_sub)
+        has_footer = bool(content.footer_source)
+
+        # Make room for callout + footer when present.
         left = Inches(0.4)
         top = Inches(0.3)
         width = Inches(12.5)
-        max_height = Inches(6.8)
+        max_height = Inches(6.0 if (has_callout or has_footer) else 6.8)
 
         if content.images and Path(content.images[0]).exists():
             self._add_fitted_picture(slide, content.images[0], left, top, width, max_height=max_height)
+
+        if has_callout:
+            self._draw_callout_box(slide, content)
+        if has_footer:
+            self._draw_footer_band(slide, content)
 
         # Add speaker notes with the title text for reference
         if content.notes_text or content.title:
             notes = slide.notes_slide
             notes.notes_text_frame.text = content.notes_text or content.title
+
+    def _draw_callout_box(self, slide, content: SlideContent) -> None:
+        """Draw the spec-driven callout box at the bottom-center of the slide.
+
+        Layout per SLIDE_DESIGN.md callout anatomy:
+          - Hero number 44pt bold accent (CSI orange)
+          - Sub label 14pt semibold navy
+          - Tertiary line 11pt regular text
+        Box has an accent-colored left border so the eye reads it as a
+        consultant-style sidebar.
+        """
+        from pptx.dml.color import RGBColor
+        from pptx.enum.shapes import MSO_SHAPE
+        from pptx.util import Emu, Inches, Pt
+
+        try:
+            from ars_analysis.shared.brand import BRAND
+        except Exception:
+            # Fallback to CSI canonicals if brand isn't importable
+            BRAND = {"navy": "#1A1A1A", "accent": "#F15D22", "text": "#222222"}
+
+        def _hex(color: str) -> "RGBColor":
+            color = color.lstrip("#")
+            return RGBColor(int(color[0:2], 16), int(color[2:4], 16), int(color[4:6], 16))
+
+        # Geometry: 12" wide × 1.2" tall, centered horizontally, just below chart.
+        left = Inches(0.6)
+        top = Inches(6.0)
+        width = Inches(12.1)
+        height = Inches(1.15)
+        box = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, left, top, width, height)
+        box.fill.solid()
+        box.fill.fore_color.rgb = _hex("#FFFFFF")
+        # Accent left border
+        box.line.color.rgb = _hex(BRAND["accent"])
+        box.line.width = Pt(3)
+
+        # Stack hero / sub / tertiary inside the box via a text frame.
+        tf = box.text_frame
+        tf.margin_left = Inches(0.25)
+        tf.margin_right = Inches(0.25)
+        tf.margin_top = Inches(0.10)
+        tf.margin_bottom = Inches(0.10)
+        tf.word_wrap = True
+
+        # Hero (first paragraph already exists)
+        p = tf.paragraphs[0]
+        p.text = content.callout_hero or ""
+        for run in p.runs:
+            run.font.name = "Montserrat"
+            run.font.size = Pt(28)
+            run.font.bold = True
+            run.font.color.rgb = _hex(BRAND["accent"])
+
+        if content.callout_sub:
+            p2 = tf.add_paragraph()
+            p2.text = content.callout_sub
+            for run in p2.runs:
+                run.font.name = "Montserrat"
+                run.font.size = Pt(14)
+                run.font.bold = True
+                run.font.color.rgb = _hex(BRAND["navy"])
+
+        if content.callout_tertiary:
+            p3 = tf.add_paragraph()
+            p3.text = content.callout_tertiary
+            for run in p3.runs:
+                run.font.name = "Montserrat"
+                run.font.size = Pt(11)
+                run.font.color.rgb = _hex(BRAND.get("text", "#222222"))
+
+    def _draw_footer_band(self, slide, content: SlideContent) -> None:
+        """Draw the spec-driven footer band at the very bottom of the slide.
+
+        Two short lines: source (italic) and confidentiality. Both 9pt muted.
+        """
+        from pptx.dml.color import RGBColor
+        from pptx.util import Inches, Pt
+
+        try:
+            from ars_analysis.shared.brand import BRAND
+        except Exception:
+            BRAND = {"text_muted": "#777777"}
+
+        muted = BRAND.get("text_muted", "#777777").lstrip("#")
+        muted_rgb = RGBColor(int(muted[0:2], 16), int(muted[2:4], 16), int(muted[4:6], 16))
+
+        left = Inches(0.6)
+        top = Inches(7.25)
+        width = Inches(12.1)
+        height = Inches(0.35)
+        tb = slide.shapes.add_textbox(left, top, width, height)
+        tf = tb.text_frame
+        tf.word_wrap = True
+        tf.margin_left = Inches(0)
+        tf.margin_top = Inches(0)
+        tf.margin_bottom = Inches(0)
+
+        p = tf.paragraphs[0]
+        p.text = content.footer_source
+        for run in p.runs:
+            run.font.name = "Montserrat"
+            run.font.size = Pt(9)
+            run.font.italic = True
+            run.font.color.rgb = muted_rgb
+
+        if content.footer_confidentiality:
+            p2 = tf.add_paragraph()
+            p2.text = content.footer_confidentiality
+            for run in p2.runs:
+                run.font.name = "Montserrat"
+                run.font.size = Pt(8)
+                run.font.color.rgb = muted_rgb
 
     def _build_screenshot_kpi_slide(self, slide, content: SlideContent) -> None:
         """Build slide with image and KPI callouts.

--- a/01_Analysis/00-Scripts/output/deck_builder.py
+++ b/01_Analysis/00-Scripts/output/deck_builder.py
@@ -91,6 +91,15 @@ class SlideContent:
     bullets: list[str] | None = None
     layout_index: int = 8  # LAYOUT_CUSTOM (default for most slides)
     notes_text: str | None = None
+    # Wave 3 (slide spec system): action-slide anatomy from docs/slide_specs/*.yml.
+    # When populated, the deck builder renders callout box + footer band per
+    # SLIDE_DESIGN.md. When empty, falls back to legacy screenshot layout.
+    callout_hero: str = ""
+    callout_sub: str = ""
+    callout_tertiary: str = ""
+    footer_source: str = ""
+    footer_confidentiality: str = ""
+    denominator_label: str = ""
 
 
 # =============================================================================
@@ -1602,6 +1611,39 @@ def _result_to_slide(result, ctx_results: dict | None = None) -> SlideContent | 
         title = generate_headline(slide_id, insights, fallback_title=title)
         notes_text = generate_notes(slide_id, title, insights, kpis=kpis)
 
+    # Wave 3: spec-driven override. When a YAML spec exists for this slide_id,
+    # render its action_title / callout / footer from ctx.results and use them
+    # in place of the analytics-supplied title. Fall through silently when no
+    # spec is authored (so legacy behavior holds for un-spec'd sections).
+    callout_hero = callout_sub = callout_tertiary = ""
+    footer_source = footer_confidentiality = ""
+    denominator_label = ""
+    if slide_id and ctx_results is not None:
+        try:
+            from ars_analysis.output import slide_spec as _spec
+
+            section = _spec_section_for(slide_id)
+            spec_obj = _spec.get_spec(section, slide_id) if section else None
+            if spec_obj is not None and spec_obj.action_title:
+                rendered = _spec.render_spec(spec_obj, ctx_results, getattr(_CURRENT_CLIENT, "info", None))
+                if rendered.action_title and "{" not in rendered.action_title:
+                    title = rendered.action_title
+                callout_hero = rendered.callout_hero
+                callout_sub = rendered.callout_sub
+                callout_tertiary = rendered.callout_tertiary
+                footer_source = rendered.footer_source
+                footer_confidentiality = rendered.footer_confidentiality
+                denominator_label = rendered.denominator_label
+                if rendered.render_warnings:
+                    from loguru import logger as _log
+                    _log.debug(
+                        "slide_spec {sid} render warnings: {w}",
+                        sid=slide_id, w=rendered.render_warnings,
+                    )
+        except Exception as _exc:  # pragma: no cover -- diagnostic only
+            from loguru import logger as _log
+            _log.debug("slide_spec render skipped for {sid}: {e}", sid=slide_id, e=_exc)
+
     return SlideContent(
         slide_type=slide_type,
         title=title,
@@ -1610,7 +1652,45 @@ def _result_to_slide(result, ctx_results: dict | None = None) -> SlideContent | 
         kpis=kpis,
         layout_index=layout_idx,
         notes_text=notes_text,
+        callout_hero=callout_hero,
+        callout_sub=callout_sub,
+        callout_tertiary=callout_tertiary,
+        footer_source=footer_source,
+        footer_confidentiality=footer_confidentiality,
+        denominator_label=denominator_label,
     )
+
+
+def _spec_section_for(slide_id: str) -> str:
+    """Map a slide_id to its YAML spec section. Returns '' when unknown."""
+    sid = slide_id.upper()
+    if sid.startswith("DCTR") or sid.startswith("A7"):
+        return "dctr"
+    if sid.startswith("REGE") or sid.startswith("A8"):
+        return "rege"
+    if sid.startswith("A9") or "ATTRITION" in sid:
+        return "attrition"
+    if sid.startswith("A11") or "VALUE" in sid:
+        return "value"
+    if sid.startswith("A12") or sid.startswith("A13") or sid.startswith("A14") or "MAILER" in sid:
+        return "mailer"
+    if sid.startswith("S") or "INSIGHTS" in sid or "DORMANT" in sid:
+        return "insights"
+    if sid.startswith("A1") or "OVERVIEW" in sid:
+        return "overview"
+    if "COMPETITION" in sid:
+        return "competition"
+    if "TXN" in sid:
+        return "txn_exec"
+    return ""
+
+
+# Per-thread/per-run client snapshot used by spec rendering for {client_name},
+# {month}, etc. Set by build_deck() at the start of a run; reset on completion.
+class _CurrentClient:
+    info: object | None = None
+
+_CURRENT_CLIENT = _CurrentClient()
 
 
 # =============================================================================
@@ -1748,6 +1828,8 @@ def build_deck(ctx: PipelineContext) -> Path | None:
     # kept (they belong in the aux deck) while N-marked still drop.
     global _CURRENT_MANIFEST, _CURRENT_AUX_BUILD
     _CURRENT_AUX_BUILD = bool(getattr(ctx, "_aux_build", False))
+    # Wave 3: expose ctx.client to spec rendering for {client_name} / {month} templates.
+    _CURRENT_CLIENT.info = ctx.client
     if not _CURRENT_AUX_BUILD:
         _CURRENT_MANIFEST = load_manifest_decisions()
         logger.info(_CURRENT_MANIFEST.summary())

--- a/01_Analysis/00-Scripts/output/slide_spec.py
+++ b/01_Analysis/00-Scripts/output/slide_spec.py
@@ -1,0 +1,305 @@
+"""YAML-driven slide specification loader and renderer.
+
+A slide spec is data: action title template, callout text, footer line, and
+inputs that resolve against ctx.results. The renderer walks the spec, fills
+templates from ctx, and returns SlideContent that deck_builder can lay out.
+
+Specs live in docs/slide_specs/<section>.yml. Each spec keyed by slide_id.
+This decouples slide copy from analytics code -- product/design changes the
+spec, the analytics doesn't recompile.
+
+Spec schema (per slide):
+
+    SLIDE_ID:
+      layout: TWO_CONTENT          # one of LAYOUTS in deck_builder
+      components: [A7.6a, DCTR-7]  # chart ids contributing to this slide
+      action_title: "L12M DCTR of {l12m_rate:.0%} {direction} ..."
+      inputs:                      # dotted-path resolvers against ctx.results
+        l12m_rate: ctx.results.dctr_3.insights.dctr
+        direction: "trails if gap_pp<0 else beats"  # expression -- evaluated
+      denominator_label: Eligible  # ties Wave 1 law to this slide
+      callout:
+        hero: "${delta_revenue:,.1f}M"
+        sub:  "annual debit interchange uplift"
+        tertiary: "Closing the gap at {b1}, {b2}, {b3}"
+      footer:
+        source: "Source: {client_name} ODD, {month} | N = {eligible_count:,}"
+
+Wave 3 wires render_spec into deck_builder._result_to_slide as an opt-in
+fallback: when a spec exists for a slide_id, render from it; otherwise keep
+today's behavior. Zero-risk rollout, spec by spec.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML pinned in requirements
+    yaml = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CalloutSpec:
+    hero: str = ""
+    sub: str = ""
+    tertiary: str = ""
+
+
+@dataclass
+class FooterSpec:
+    source: str = ""
+    confidentiality: str = "Confidential — for internal CSM/client use only"
+
+
+@dataclass
+class SlideSpec:
+    slide_id: str = ""
+    layout: str = "TWO_CONTENT"
+    components: list[str] = field(default_factory=list)
+    action_title: str = ""
+    inputs: dict[str, str] = field(default_factory=dict)
+    denominator_label: str = ""
+    callout: CalloutSpec = field(default_factory=CalloutSpec)
+    footer: FooterSpec = field(default_factory=FooterSpec)
+
+
+@dataclass
+class SlideContent:
+    """Rendered output the deck builder consumes."""
+
+    slide_id: str = ""
+    layout: str = "TWO_CONTENT"
+    action_title: str = ""
+    components: list[str] = field(default_factory=list)
+    callout_hero: str = ""
+    callout_sub: str = ""
+    callout_tertiary: str = ""
+    footer_source: str = ""
+    footer_confidentiality: str = ""
+    denominator_label: str = ""
+    # If anything failed to resolve cleanly, populate this so the deck builder
+    # can fall back gracefully and we log a precise reason.
+    render_warnings: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_SPECS_DIR = (
+    Path(__file__).resolve().parent.parent.parent.parent / "docs" / "slide_specs"
+)
+
+
+def specs_dir() -> Path:
+    """Return the directory to load specs from. Override with SLIDE_SPECS_DIR."""
+    env = os.environ.get("SLIDE_SPECS_DIR")
+    if env:
+        return Path(env)
+    return _DEFAULT_SPECS_DIR
+
+
+def _parse_spec_dict(slide_id: str, raw: dict) -> SlideSpec:
+    callout = raw.get("callout") or {}
+    footer = raw.get("footer") or {}
+    return SlideSpec(
+        slide_id=slide_id,
+        layout=raw.get("layout", "TWO_CONTENT"),
+        components=list(raw.get("components") or []),
+        action_title=raw.get("action_title", ""),
+        inputs=dict(raw.get("inputs") or {}),
+        denominator_label=raw.get("denominator_label", ""),
+        callout=CalloutSpec(
+            hero=callout.get("hero", ""),
+            sub=callout.get("sub", ""),
+            tertiary=callout.get("tertiary", ""),
+        ),
+        footer=FooterSpec(
+            source=footer.get("source", ""),
+            confidentiality=footer.get(
+                "confidentiality",
+                "Confidential — for internal CSM/client use only",
+            ),
+        ),
+    )
+
+
+def load_specs(section: str) -> dict[str, SlideSpec]:
+    """Parse docs/slide_specs/<section>.yml into a {slide_id: SlideSpec} map.
+
+    Returns an empty dict if the file is missing, PyYAML is unavailable, or the
+    YAML is empty. Never raises; failures log a warning.
+    """
+    if yaml is None:
+        logger.warning("slide_spec: PyYAML not installed; specs disabled")
+        return {}
+
+    path = specs_dir() / f"{section}.yml"
+    if not path.exists():
+        return {}
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        logger.warning("slide_spec: failed to parse {p}: {err}", p=path, err=exc)
+        return {}
+
+    out: dict[str, SlideSpec] = {}
+    for slide_id, body in raw.items():
+        if not isinstance(body, dict):
+            continue
+        out[str(slide_id)] = _parse_spec_dict(str(slide_id), body)
+    logger.info("slide_spec: loaded {n} spec(s) for section {s}", n=len(out), s=section)
+    return out
+
+
+# Cache so we don't re-parse a YAML file per slide.
+_SPEC_CACHE: dict[str, dict[str, SlideSpec]] = {}
+
+
+def get_spec(section: str, slide_id: str) -> SlideSpec | None:
+    """Look up a single spec, loading and caching the section file as needed."""
+    if section not in _SPEC_CACHE:
+        _SPEC_CACHE[section] = load_specs(section)
+    return _SPEC_CACHE[section].get(slide_id)
+
+
+def clear_spec_cache() -> None:
+    _SPEC_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+def _resolve_dotted(path: str, ctx_results: dict[str, Any]) -> Any:
+    """Resolve 'ctx.results.dctr_3.insights.dctr' against ctx_results.
+
+    The leading 'ctx.results.' prefix is optional. Returns None if any step
+    along the path is missing.
+    """
+    tokens = path.split(".")
+    if tokens[:2] == ["ctx", "results"]:
+        tokens = tokens[2:]
+    cur: Any = ctx_results
+    for tok in tokens:
+        if cur is None:
+            return None
+        if isinstance(cur, dict):
+            cur = cur.get(tok)
+        else:
+            cur = getattr(cur, tok, None)
+    return cur
+
+
+_SAFE_BUILTINS = {
+    "abs": abs, "min": min, "max": max, "round": round,
+    "len": len, "int": int, "float": float, "str": str,
+}
+
+
+def _evaluate_input(expr: str, namespace: dict[str, Any]) -> Any:
+    """Evaluate one inputs entry.
+
+    Three flavors:
+      - Dotted path resolving to ctx.results.* (returns the value).
+      - Quoted literal (returns the string).
+      - Python expression using already-resolved names in namespace.
+
+    Restricted eval -- no builtins outside _SAFE_BUILTINS. Returns None on error.
+    """
+    expr = expr.strip()
+    if not expr:
+        return None
+    # Bare dotted path against ctx.results
+    if expr.startswith("ctx.") or expr.startswith("ctx.results"):
+        return _resolve_dotted(expr, namespace.get("__ctx_results__", {}))
+    # Quoted literal
+    if (expr.startswith('"') and expr.endswith('"')) or (
+        expr.startswith("'") and expr.endswith("'")
+    ):
+        return expr[1:-1]
+    # Try treating as expression
+    try:
+        return eval(expr, {"__builtins__": _SAFE_BUILTINS}, namespace)
+    except Exception as exc:
+        logger.debug("slide_spec: input expression failed ({e}): {x}", e=exc, x=expr)
+        return None
+
+
+def _format(template: str, ns: dict[str, Any]) -> tuple[str, list[str]]:
+    """Format `template` with the namespace; collect names that couldn't resolve."""
+    warnings: list[str] = []
+
+    class _Lenient(dict):
+        def __missing__(self, key):  # type: ignore[override]
+            warnings.append(f"missing input '{key}'")
+            return "{" + key + "}"
+
+    try:
+        rendered = template.format_map(_Lenient(ns))
+    except Exception as exc:
+        warnings.append(f"format failed: {exc}")
+        rendered = template
+    return rendered, warnings
+
+
+def render_spec(
+    spec: SlideSpec,
+    ctx_results: dict[str, Any],
+    client_info: Any | None = None,
+) -> SlideContent:
+    """Resolve a spec against ctx.results and return rendered SlideContent.
+
+    `client_info` is the ctx.client object; its public attributes (`client_name`,
+    `month`, `client_id`) are exposed to the template namespace by name.
+    """
+    ns: dict[str, Any] = {"__ctx_results__": ctx_results}
+
+    # Expose client metadata
+    if client_info is not None:
+        for attr in ("client_name", "month", "client_id", "csm"):
+            if hasattr(client_info, attr):
+                ns[attr] = getattr(client_info, attr)
+
+    # Resolve inputs in declaration order so later expressions can use earlier ones
+    warnings: list[str] = []
+    for name, expr in spec.inputs.items():
+        ns[name] = _evaluate_input(str(expr), ns)
+        if ns[name] is None and name in str(spec.action_title):
+            warnings.append(f"input '{name}' resolved to None")
+
+    action_title, w1 = _format(spec.action_title, ns)
+    hero, w2 = _format(spec.callout.hero, ns)
+    sub, w3 = _format(spec.callout.sub, ns)
+    tertiary, w4 = _format(spec.callout.tertiary, ns)
+    source, w5 = _format(spec.footer.source, ns)
+    warnings += w1 + w2 + w3 + w4 + w5
+
+    return SlideContent(
+        slide_id=spec.slide_id,
+        layout=spec.layout,
+        action_title=action_title,
+        components=list(spec.components),
+        callout_hero=hero,
+        callout_sub=sub,
+        callout_tertiary=tertiary,
+        footer_source=source,
+        footer_confidentiality=spec.footer.confidentiality,
+        denominator_label=spec.denominator_label,
+        render_warnings=warnings,
+    )

--- a/01_Analysis/00-Scripts/tests/test_slide_spec.py
+++ b/01_Analysis/00-Scripts/tests/test_slide_spec.py
@@ -1,0 +1,145 @@
+"""Tests for the YAML slide-spec loader and renderer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from ars_analysis.output import slide_spec as ss
+
+
+@dataclass
+class _Client:
+    client_id: str = "1615"
+    client_name: str = "AcmeCU"
+    month: str = "2026.04"
+    csm: str = "James"
+
+
+@pytest.fixture
+def specs_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLIDE_SPECS_DIR", str(tmp_path))
+    ss.clear_spec_cache()
+    return tmp_path
+
+
+def test_load_specs_missing_section_returns_empty(specs_dir):
+    assert ss.load_specs("nope") == {}
+
+
+def test_load_specs_parses_basic_yml(specs_dir):
+    (specs_dir / "demo.yml").write_text(
+        """
+DEMO-1:
+  layout: TWO_CONTENT
+  components: [A1]
+  action_title: "Hello {client_name}"
+  denominator_label: Eligible
+  inputs:
+    rate: ctx.results.demo.insights.rate
+  callout:
+    hero: "{rate:.0%}"
+    sub: "demo rate"
+  footer:
+    source: "Source: {client_name} ODD"
+"""
+    )
+    specs = ss.load_specs("demo")
+    assert "DEMO-1" in specs
+    spec = specs["DEMO-1"]
+    assert spec.layout == "TWO_CONTENT"
+    assert spec.components == ["A1"]
+    assert spec.action_title == "Hello {client_name}"
+    assert spec.denominator_label == "Eligible"
+    assert spec.callout.hero == "{rate:.0%}"
+    assert spec.footer.source.startswith("Source:")
+
+
+def test_get_spec_caches(specs_dir):
+    (specs_dir / "x.yml").write_text("X1:\n  action_title: hi\n")
+    a = ss.get_spec("x", "X1")
+    b = ss.get_spec("x", "X1")
+    assert a is b  # cached -- same object
+
+
+def test_resolve_dotted_walks_nested_dicts():
+    results = {"dctr_1": {"insights": {"dctr": 0.31}}}
+    assert ss._resolve_dotted("ctx.results.dctr_1.insights.dctr", results) == 0.31
+    assert ss._resolve_dotted("dctr_1.insights.dctr", results) == 0.31
+    assert ss._resolve_dotted("dctr_1.insights.missing", results) is None
+
+
+def test_render_spec_fills_action_title_with_ctx_values(specs_dir):
+    (specs_dir / "demo.yml").write_text(
+        """
+DEMO:
+  action_title: "DCTR {rate:.0%} for {client_name}"
+  inputs:
+    rate: ctx.results.dctr_1.insights.dctr
+"""
+    )
+    spec = ss.get_spec("demo", "DEMO")
+    rendered = ss.render_spec(
+        spec,
+        {"dctr_1": {"insights": {"dctr": 0.31}}},
+        _Client(),
+    )
+    assert rendered.action_title == "DCTR 31% for AcmeCU"
+    assert rendered.render_warnings == []
+
+
+def test_render_spec_lenient_on_missing_inputs(specs_dir):
+    (specs_dir / "demo.yml").write_text(
+        """
+DEMO:
+  action_title: "Rate is {rate:.0%}"
+  inputs:
+    rate: ctx.results.missing.insights.rate
+"""
+    )
+    spec = ss.get_spec("demo", "DEMO")
+    rendered = ss.render_spec(spec, {}, _Client())
+    # Should keep the literal placeholder and surface a warning, NOT raise
+    assert "{rate" in rendered.action_title or "{rate:.0%}" in rendered.action_title
+    assert any("missing input" in w or "format failed" in w or "resolved to None" in w
+               for w in rendered.render_warnings)
+
+
+def test_render_spec_passes_callout_and_footer_through(specs_dir):
+    (specs_dir / "demo.yml").write_text(
+        """
+DEMO:
+  action_title: "Static title"
+  denominator_label: Eligible Personal
+  callout:
+    hero: "$5.2M"
+    sub: "uplift"
+  footer:
+    source: "Source: {client_name} ODD, {month}"
+"""
+    )
+    spec = ss.get_spec("demo", "DEMO")
+    rendered = ss.render_spec(spec, {}, _Client())
+    assert rendered.callout_hero == "$5.2M"
+    assert rendered.callout_sub == "uplift"
+    assert "AcmeCU" in rendered.footer_source
+    assert "2026.04" in rendered.footer_source
+    assert rendered.denominator_label == "Eligible Personal"
+
+
+def test_repo_specs_load_without_error():
+    """The dctr.yml and rege.yml shipped with the repo must parse."""
+    ss.clear_spec_cache()
+    # SLIDE_SPECS_DIR not set -> uses _DEFAULT_SPECS_DIR
+    dctr = ss.load_specs("dctr")
+    rege = ss.load_specs("rege")
+    assert len(dctr) >= 1, "dctr.yml should declare at least one slide"
+    assert len(rege) >= 1, "rege.yml should declare at least one slide"
+    # Every spec must declare a 4-layer-compliant denominator_label
+    valid_labels = {"Eligible", "Eligible Personal", "Eligible Business", "Open"}
+    for spec in list(dctr.values()) + list(rege.values()):
+        assert spec.denominator_label in valid_labels, (
+            f"{spec.slide_id}: denominator_label '{spec.denominator_label}' "
+            f"not in 4-layer law"
+        )

--- a/01_Analysis/00-Scripts/tests/test_slide_spec.py
+++ b/01_Analysis/00-Scripts/tests/test_slide_spec.py
@@ -129,17 +129,18 @@ DEMO:
 
 
 def test_repo_specs_load_without_error():
-    """The dctr.yml and rege.yml shipped with the repo must parse."""
+    """Every authored spec across all sections must parse and be 4-layer compliant."""
     ss.clear_spec_cache()
     # SLIDE_SPECS_DIR not set -> uses _DEFAULT_SPECS_DIR
-    dctr = ss.load_specs("dctr")
-    rege = ss.load_specs("rege")
-    assert len(dctr) >= 1, "dctr.yml should declare at least one slide"
-    assert len(rege) >= 1, "rege.yml should declare at least one slide"
-    # Every spec must declare a 4-layer-compliant denominator_label
+    authored_sections = ("dctr", "rege", "overview", "attrition", "value", "insights")
+    by_section = {s: ss.load_specs(s) for s in authored_sections}
+    for section, specs in by_section.items():
+        assert len(specs) >= 1, f"{section}.yml should declare at least one slide"
+
     valid_labels = {"Eligible", "Eligible Personal", "Eligible Business", "Open"}
-    for spec in list(dctr.values()) + list(rege.values()):
-        assert spec.denominator_label in valid_labels, (
-            f"{spec.slide_id}: denominator_label '{spec.denominator_label}' "
-            f"not in 4-layer law"
-        )
+    for section, specs in by_section.items():
+        for spec in specs.values():
+            assert spec.denominator_label in valid_labels, (
+                f"{section}/{spec.slide_id}: denominator_label "
+                f"'{spec.denominator_label}' not in 4-layer law"
+            )

--- a/01_Analysis/00-Scripts/tests/test_slide_spec.py
+++ b/01_Analysis/00-Scripts/tests/test_slide_spec.py
@@ -132,7 +132,7 @@ def test_repo_specs_load_without_error():
     """Every authored spec across all sections must parse and be 4-layer compliant."""
     ss.clear_spec_cache()
     # SLIDE_SPECS_DIR not set -> uses _DEFAULT_SPECS_DIR
-    authored_sections = ("dctr", "rege", "overview", "attrition", "value", "insights")
+    authored_sections = ("dctr", "rege", "overview", "attrition", "value", "insights", "mailer")
     by_section = {s: ss.load_specs(s) for s in authored_sections}
     for section, specs in by_section.items():
         assert len(specs) >= 1, f"{section}.yml should declare at least one slide"

--- a/docs/slide_specs/_TEMPLATE.yml
+++ b/docs/slide_specs/_TEMPLATE.yml
@@ -1,0 +1,26 @@
+# Slide spec template -- copy to <section>.yml and replace placeholders.
+# Loader: 01_Analysis/00-Scripts/output/slide_spec.py
+#
+# Validation hooks (Wave 1 + Wave 3):
+#   - denominator_label must be one of: Eligible / Eligible Personal /
+#     Eligible Business / Open. Open is only legal on whitelisted slides
+#     (currently DCTR-MAIN-2 only).
+#   - action_title is the headline. Format placeholders use Python format-spec
+#     syntax: {name:.0%} for percent, {name:,.1f}M for currency, etc.
+#   - inputs map declared names to ctx.results paths or expressions. They
+#     evaluate in declaration order, so later inputs can reference earlier
+#     ones.
+
+SAMPLE-SLIDE-ID:
+  layout: TWO_CONTENT                 # one of the layouts deck_builder supports
+  components: [A1.1]                  # chart_ids that contribute to this slide
+  action_title: "Headline with a {metric:.0%} number in it"
+  inputs:
+    metric: ctx.results.module_id.insights.rate
+  denominator_label: Eligible         # 4-layer law
+  callout:
+    hero: "${value:,.1f}M"
+    sub:  "annual uplift"
+    tertiary: "Closing the gap drives the hero number"
+  footer:
+    source: "Source: {client_name} ODD, {month}"

--- a/docs/slide_specs/attrition.yml
+++ b/docs/slide_specs/attrition.yml
@@ -1,6 +1,36 @@
-# attrition section slide specs.
-# TODO(W3 follow-up): author specs for main-deck slides in this section.
-# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
-# Until specs exist here, deck_builder falls back to today's behavior
-# (analytics-supplied titles), so empty file is safe.
+# Attrition section slide specs.
+# Per the 4-layer law: attrition rates anchor to the Eligible layer
+# (closures / eligible_total). All dollar figures derived from Eligible base.
 
+ATTRITION-MAIN-1:
+  layout: TWO_CONTENT
+  components: [A9.1]
+  action_title: "Overall attrition of {rate:.1%}; L12M trending {direction} at {l12m_rate:.1%}"
+  inputs:
+    rate: ctx.results.attrition_1.overall_rate
+    l12m_rate: ctx.results.attrition_1.l12m_rate
+    total: ctx.results.attrition_1.total
+    closed: ctx.results.attrition_1.closed
+    direction: "'softer' if (l12m_rate or 0) < (rate or 0) else 'harder'"
+  denominator_label: Eligible
+  callout:
+    hero: "{closed:,}"
+    sub: "closures in the eligible base"
+    tertiary: "Out of {total:,} eligible accounts"
+  footer:
+    source: "Source: {client_name} ODD, {month} | N (Eligible) = {total:,}"
+
+ATTRITION-MAIN-2:
+  layout: TWO_CONTENT
+  components: [A9.11]
+  action_title: "Closures represent ${impact:,.0f} in annualized lost revenue"
+  inputs:
+    impact: ctx.results.attrition_11.total_lost
+    diff: ctx.results.attrition_13.diff
+  denominator_label: Eligible
+  callout:
+    hero: "${impact:,.0f}"
+    sub: "annualized revenue at risk"
+    tertiary: "Retention-lift programs offset {diff:+.0%} of this gap"
+  footer:
+    source: "Source: {client_name} ODD, {month} | Eligible base"

--- a/docs/slide_specs/attrition.yml
+++ b/docs/slide_specs/attrition.yml
@@ -1,0 +1,6 @@
+# attrition section slide specs.
+# TODO(W3 follow-up): author specs for main-deck slides in this section.
+# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
+# Until specs exist here, deck_builder falls back to today's behavior
+# (analytics-supplied titles), so empty file is safe.
+

--- a/docs/slide_specs/competition.yml
+++ b/docs/slide_specs/competition.yml
@@ -1,0 +1,6 @@
+# competition section slide specs.
+# TODO(W3 follow-up): author specs for main-deck slides in this section.
+# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
+# Until specs exist here, deck_builder falls back to today's behavior
+# (analytics-supplied titles), so empty file is safe.
+

--- a/docs/slide_specs/competition.yml
+++ b/docs/slide_specs/competition.yml
@@ -1,6 +1,13 @@
-# competition section slide specs.
-# TODO(W3 follow-up): author specs for main-deck slides in this section.
-# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
-# Until specs exist here, deck_builder falls back to today's behavior
-# (analytics-supplied titles), so empty file is safe.
-
+# Competition section slide specs.
+#
+# DEFERRED: Competition is a TXN section. Its modules are numbered scripts
+# (01_competitor_config.py through 70_banking_vs_ecosystems.py) that produce
+# Plotly charts directly without populating ctx.results in the dict shape the
+# slide_spec renderer binds to. Authoring specs here first needs a thin
+# TXN-section results adapter (per-script insights -> ctx.results["competition_<id>"]).
+#
+# Roadmap: when txn_setup is extended to expose per-script insights dicts,
+# add specs for COMPETITION-MAIN-THREAT-QUADRANT (slide 13_threat_quadrant)
+# and COMPETITION-MAIN-WALLET-SHARE (24_segment_heatmap derivative). Until
+# then, deck_builder falls back to today's behavior (Plotly-rendered titles),
+# so this empty file is safe.

--- a/docs/slide_specs/dctr.yml
+++ b/docs/slide_specs/dctr.yml
@@ -1,0 +1,70 @@
+# DCTR section slide specs.
+# Source of truth for action titles, callouts, and footer band of every
+# DCTR slide on the main deck. See docs/slide_specs/dctr.md for the
+# full design narrative (panel layouts, color rules, etc).
+#
+# Schema: 01_Analysis/00-Scripts/output/slide_spec.py
+# Wire-in: output/deck_builder.py reads via output/slide_spec.get_spec("dctr", slide_id).
+# Denominator law: every rate on these slides is computed against Eligible
+# (open ∩ eligible_stat ∩ eligible_prod). DCTR-MAIN-2 is the only exception --
+# it explicitly contrasts Eligible vs Open as the methodology slide.
+
+DCTR-MAIN-1:
+  layout: TWO_CONTENT
+  components: [A7.6a, DCTR-7]
+  action_title: "L12M DCTR of {l12m_rate:.0%} {direction} historical by {gap_pp_abs:.0f}pp; {top_n} branches drive {contribution:.0%} of the gap"
+  inputs:
+    l12m_rate: ctx.results.dctr_3.insights.dctr
+    overall_rate: ctx.results.dctr_1.insights.overall_dctr
+    gap_pp: (l12m_rate - overall_rate) * 100
+    gap_pp_abs: abs(gap_pp) if gap_pp is not None else 0
+    direction: "'trails' if (gap_pp or 0) < 0 else ('matches' if abs(gap_pp or 0) < 1 else 'beats')"
+    top_n: "3"
+    contribution: ctx.results.dctr_7.gap_contributors.share_top3
+  denominator_label: Eligible
+  callout:
+    hero: "${delta_revenue:,.1f}M"
+    sub: "annual debit interchange uplift"
+    tertiary: "Closing the gap at {b1}, {b2}, {b3} to portfolio-median DCTR"
+  footer:
+    source: "Source: {client_name} ODD, {month} | N (Eligible) = {eligible_count:,}"
+
+DCTR-MAIN-2:
+  layout: TWO_CONTENT
+  components: [DCTR-2]
+  action_title: "{eligible_pct:.0%} of open accounts pass eligibility filters; DCTR among the eligible is {elig_dctr:.0%}"
+  inputs:
+    open_total: ctx.results.dctr_2.insights.open_total
+    eligible_total: ctx.results.dctr_2.insights.eligible_total
+    eligible_pct: eligible_total / open_total if open_total else 0
+    elig_dctr: ctx.results.dctr_2.insights.eligible_dctr
+    open_dctr: ctx.results.dctr_2.insights.open_dctr
+  # NOTE: DCTR-MAIN-2 is the ONE slide where Open is allowed as a primary
+  # denominator framing -- this is the methodology slide that explains why
+  # every other DCTR slide reports against Eligible. Audit step's OPEN_ALLOWLIST
+  # whitelists it.
+  denominator_label: Open
+  callout:
+    hero: "{elig_dctr:.0%}"
+    sub: "Eligible DCTR (primary)"
+    tertiary: "vs {open_dctr:.0%} across all open accounts (reference framing)"
+  footer:
+    source: "Source: {client_name} ODD, {month}"
+
+DCTR-MAIN-3:
+  layout: TWO_CONTENT
+  components: [DCTR-4, DCTR-5]
+  action_title: "Personal DCTR {p_rate:.0%}{vs_business}; the gap is concentrated in {gap_segment}"
+  inputs:
+    p_rate: ctx.results.dctr_4.insights.dctr
+    b_rate: ctx.results.dctr_5.insights.dctr
+    pb_gap: (p_rate or 0) - (b_rate or 0)
+    vs_business: "' vs Business ' + format((b_rate or 0)*100, '.0f') + '%'"
+    gap_segment: "'Business' if (pb_gap or 0) > 0 else 'Personal'"
+  denominator_label: Eligible
+  callout:
+    hero: "{pb_gap_pp:+.0f}pp"
+    sub: "Personal vs Business DCTR gap"
+    tertiary: "Closing the {gap_segment} gap is the biggest single lever"
+  footer:
+    source: "Source: {client_name} ODD, {month} | Eligible Personal + Eligible Business"

--- a/docs/slide_specs/insights.yml
+++ b/docs/slide_specs/insights.yml
@@ -1,6 +1,54 @@
-# insights section slide specs.
-# TODO(W3 follow-up): author specs for main-deck slides in this section.
-# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
-# Until specs exist here, deck_builder falls back to today's behavior
-# (analytics-supplied titles), so empty file is safe.
+# Insights section slide specs.
+# The "S" slides synthesize the rest of the deck. Every rate referenced here
+# already comes from upstream modules that anchor to the Eligible layer
+# (Wave 1 audit enforces this), so the labels here are inherited rather than
+# re-declared per metric.
 
+INSIGHTS-MAIN-1:
+  layout: TWO_CONTENT
+  components: [S1]
+  action_title: "Total revenue gap of ${total_gap:,.0f}; ${realistic:,.0f} is realistically capturable"
+  inputs:
+    debit_gap: ctx.results.impact_s1.debit_gap
+    rege_gap: ctx.results.impact_s1.rege_gap
+    total_gap: ctx.results.impact_s1.total_gap
+    realistic: ctx.results.impact_s1.realistic_capture
+  denominator_label: Eligible
+  callout:
+    hero: "${realistic:,.0f}"
+    sub: "realistic annual capture"
+    tertiary: "Debit gap ${debit_gap:,.0f} + Reg E gap ${rege_gap:,.0f}"
+  footer:
+    source: "Source: {client_name} ODD, {month} | composite Eligible-base gaps"
+
+INSIGHTS-MAIN-6:
+  layout: TWO_CONTENT
+  components: [S6]
+  action_title: "Opportunity map: {top_count} highest-leverage branches account for {top_share:.0%} of upside"
+  inputs:
+    top_count: ctx.results.impact_s6.top_count
+    top_share: ctx.results.impact_s6.top_share
+    total_upside: ctx.results.impact_s6.total_upside
+  denominator_label: Eligible
+  callout:
+    hero: "${total_upside:,.0f}"
+    sub: "total mapped upside"
+    tertiary: "Focus campaigns at the top {top_count} branches"
+  footer:
+    source: "Source: {client_name} ODD, {month} | branch-level rollup of S1 + S2"
+
+INSIGHTS-MAIN-8:
+  layout: TWO_CONTENT
+  components: [S8]
+  action_title: "Action plan: {n_actions} initiatives totaling ${total:,.0f} in modeled annual impact"
+  inputs:
+    n_actions: ctx.results.impact_s8.n_actions
+    total: ctx.results.impact_s8.total_impact
+    top_action: ctx.results.impact_s8.top_action
+  denominator_label: Eligible
+  callout:
+    hero: "${total:,.0f}"
+    sub: "modeled annual impact"
+    tertiary: "Lead with: {top_action}"
+  footer:
+    source: "Source: {client_name} ODD, {month} | initiatives derived from S1-S7"

--- a/docs/slide_specs/insights.yml
+++ b/docs/slide_specs/insights.yml
@@ -1,0 +1,6 @@
+# insights section slide specs.
+# TODO(W3 follow-up): author specs for main-deck slides in this section.
+# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
+# Until specs exist here, deck_builder falls back to today's behavior
+# (analytics-supplied titles), so empty file is safe.
+

--- a/docs/slide_specs/mailer.yml
+++ b/docs/slide_specs/mailer.yml
@@ -1,0 +1,6 @@
+# mailer section slide specs.
+# TODO(W3 follow-up): author specs for main-deck slides in this section.
+# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
+# Until specs exist here, deck_builder falls back to today's behavior
+# (analytics-supplied titles), so empty file is safe.
+

--- a/docs/slide_specs/mailer.yml
+++ b/docs/slide_specs/mailer.yml
@@ -1,6 +1,47 @@
-# mailer section slide specs.
-# TODO(W3 follow-up): author specs for main-deck slides in this section.
-# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
-# Until specs exist here, deck_builder falls back to today's behavior
-# (analytics-supplied titles), so empty file is safe.
+# Mailer section slide specs.
+# Per the 4-layer law: mailer response rates anchor to the Eligible Mailable
+# subset within Eligible (open + eligible_stat + eligible_prod + mailable_status).
+# That base is still "Eligible" for labeling -- the mailable filter is a
+# campaign-targeting filter on the numerator framing, not a denominator narrowing.
+#
+# Per-month dynamic specs: mailer has one slide per month
+# (A13.Jan26, A13.Feb26, A13.Mar26, ...). Authoring a row per month here would
+# rot quickly. Instead the aggregate slide is authored (renders every run),
+# plus a generator-prefix MAILER-MONTH-* that deck_builder.py resolves by
+# walking mailer monthly results. The prefix is documented for future use;
+# generator wiring is W3 final follow-up.
 
+MAILER-MAIN-AGG:
+  layout: TWO_CONTENT
+  components: [A13.Agg]
+  action_title: "All-time mailer: {total_mailed:,} mailed, {overall_rate:.1f}% response"
+  inputs:
+    total_mailed: ctx.results.aggregate_summary.total_mailed
+    total_resp: ctx.results.aggregate_summary.total_resp
+    overall_rate: ctx.results.aggregate_summary.overall_rate
+  denominator_label: Eligible
+  callout:
+    hero: "{overall_rate:.1f}%"
+    sub: "aggregate response rate"
+    tertiary: "{total_resp:,} respondents across {total_mailed:,} mailed"
+  footer:
+    source: "Source: {client_name} ODD, {month} | Eligible Mailable subset"
+
+MAILER-MAIN-REACH:
+  layout: TWO_CONTENT
+  components: [A14.1]
+  action_title: "Mailer reach: {organic_share:.0%} organic, {mailed_share:.0%} mailer-touched"
+  inputs:
+    total_debit: ctx.results.market_reach.total_debit
+    organic: ctx.results.market_reach.organic
+    mailed_resp: ctx.results.market_reach.mailed_resp
+    mailed_non_resp: ctx.results.market_reach.mailed_non_resp
+    organic_share: organic / total_debit if total_debit else 0
+    mailed_share: (mailed_resp + mailed_non_resp) / total_debit if total_debit else 0
+  denominator_label: Eligible
+  callout:
+    hero: "{organic_share:.0%}"
+    sub: "debit holders acquired organically"
+    tertiary: "{mailed_resp:,} mailer-responders + {mailed_non_resp:,} mailer-non-responders"
+  footer:
+    source: "Source: {client_name} ODD, {month} | All debit holders within Eligible base"

--- a/docs/slide_specs/overview.yml
+++ b/docs/slide_specs/overview.yml
@@ -1,0 +1,6 @@
+# overview section slide specs.
+# TODO(W3 follow-up): author specs for main-deck slides in this section.
+# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
+# Until specs exist here, deck_builder falls back to today's behavior
+# (analytics-supplied titles), so empty file is safe.
+

--- a/docs/slide_specs/overview.yml
+++ b/docs/slide_specs/overview.yml
@@ -1,6 +1,21 @@
-# overview section slide specs.
-# TODO(W3 follow-up): author specs for main-deck slides in this section.
-# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
-# Until specs exist here, deck_builder falls back to today's behavior
-# (analytics-supplied titles), so empty file is safe.
+# Overview section slide specs.
+# Account-composition framing for the opening slide. The "Eligible vs Open"
+# story here is the same pivot point as DCTR-MAIN-2 -- this slide sets the
+# expectation that every subsequent rate is Eligible-anchored unless flagged.
 
+OVERVIEW-MAIN-1:
+  layout: TWO_CONTENT
+  components: [A1]
+  action_title: "{open_total:,} open accounts; {elig_pct:.0%} pass eligibility filters ({elig_total:,})"
+  inputs:
+    open_total: ctx.results.dctr_2.insights.open_total
+    elig_total: ctx.results.dctr_2.insights.eligible_total
+    elig_pct: (elig_total or 0) / (open_total or 1)
+  # Overview shows both for orientation; primary downstream denominator is Eligible.
+  denominator_label: Eligible
+  callout:
+    hero: "{elig_total:,}"
+    sub: "Eligible accounts (primary base)"
+    tertiary: "{open_total:,} open across the portfolio; eligible filter narrows by stat + product code"
+  footer:
+    source: "Source: {client_name} ODD, {month}"

--- a/docs/slide_specs/rege.yml
+++ b/docs/slide_specs/rege.yml
@@ -1,0 +1,40 @@
+# Reg E section slide specs.
+# Per the 4-layer denominator law (project_denominator_framework.md), Reg E
+# is personal-only by regulation. Base = Eligible Personal. NEVER further
+# narrow to "Eligible Personal ∩ has_debit" (that was the bug fixed earlier
+# in rege/_helpers.py).
+
+REGE-MAIN-1:
+  layout: TWO_CONTENT
+  components: [A8.1, A8.2]
+  action_title: "Reg E opt-in of {opt_in_rate:.0%} among Eligible Personal accounts; {trend_word} {trend_pp:+.0f}pp L12M"
+  inputs:
+    opt_in_rate: ctx.results.reg_e_1.insights.opt_in_rate
+    overall_total: ctx.results.reg_e_1.insights.total_accounts
+    l12m_rate: ctx.results.reg_e_2.insights.l12m_opt_in
+    trend_pp: (l12m_rate - opt_in_rate) * 100 if l12m_rate and opt_in_rate else 0
+    trend_word: "'accelerating' if (trend_pp or 0) > 0 else ('flat' if abs(trend_pp or 0) < 1 else 'softening')"
+  denominator_label: Eligible Personal
+  callout:
+    hero: "{opt_in_rate:.0%}"
+    sub: "Reg E opt-in rate among Eligible Personal"
+    tertiary: "{overall_total:,} accounts in the eligible base"
+  footer:
+    source: "Source: {client_name} ODD, {month} | Eligible Personal only"
+
+REGE-MAIN-2:
+  layout: TWO_CONTENT
+  components: [A8.12, A8.3]
+  action_title: "Monthly opt-in trends: {peak_month} peak of {peak_rate:.0%}; {valley_month} low of {valley_rate:.0%}"
+  inputs:
+    peak_month: ctx.results.reg_e_4.insights.peak_month
+    peak_rate: ctx.results.reg_e_4.insights.peak_rate
+    valley_month: ctx.results.reg_e_4.insights.valley_month
+    valley_rate: ctx.results.reg_e_4.insights.valley_rate
+  denominator_label: Eligible Personal
+  callout:
+    hero: "{peak_rate:.0%}"
+    sub: "highest single-month opt-in"
+    tertiary: "Monthly trend isolates campaign + onboarding-flow impact"
+  footer:
+    source: "Source: {client_name} ODD, {month} | Eligible Personal only"

--- a/docs/slide_specs/txn_exec.yml
+++ b/docs/slide_specs/txn_exec.yml
@@ -1,6 +1,9 @@
-# txn_exec section slide specs.
-# TODO(W3 follow-up): author specs for main-deck slides in this section.
-# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
-# Until specs exist here, deck_builder falls back to today's behavior
-# (analytics-supplied titles), so empty file is safe.
-
+# Transaction executive scorecard slide specs.
+#
+# DEFERRED: Same as competition -- TXN sections use numbered scripts
+# (e.g. analytics/executive/01_*.py..05_action_roadmap.py) without ctx.results
+# dict population. Wiring specs here first needs the same TXN-results adapter.
+#
+# Roadmap: when the adapter lands, author TXN-EXEC-MAIN-1 (executive KPI
+# scorecard, sourced from executive/01..04) and TXN-EXEC-MAIN-2 (action
+# roadmap from executive/05_action_roadmap.py).

--- a/docs/slide_specs/txn_exec.yml
+++ b/docs/slide_specs/txn_exec.yml
@@ -1,0 +1,6 @@
+# txn_exec section slide specs.
+# TODO(W3 follow-up): author specs for main-deck slides in this section.
+# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
+# Until specs exist here, deck_builder falls back to today's behavior
+# (analytics-supplied titles), so empty file is safe.
+

--- a/docs/slide_specs/value.yml
+++ b/docs/slide_specs/value.yml
@@ -1,6 +1,27 @@
-# value section slide specs.
-# TODO(W3 follow-up): author specs for main-deck slides in this section.
-# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
-# Until specs exist here, deck_builder falls back to today's behavior
-# (analytics-supplied titles), so empty file is safe.
+# Value section slide specs.
+# Anchors to Eligible: value calculations use eligible-base DCTR and Reg E
+# rates per the 4-layer law. The "potential at L12M DCTR" hero number is
+# the gap between accounts with and without debit, sized at the Eligible
+# base.
 
+VALUE-MAIN-1:
+  layout: TWO_CONTENT
+  components: [A11.1]
+  action_title: "Closing the debit gap is worth ${pot_l12m:,.0f} annually at current L12M DCTR"
+  inputs:
+    delta: ctx.results.value_1.delta
+    accts_with: ctx.results.value_1.accts_with
+    accts_without: ctx.results.value_1.accts_without
+    rev_per_with: ctx.results.value_1.rev_per_with
+    rev_per_without: ctx.results.value_1.rev_per_without
+    pot_hist: ctx.results.value_1.pot_hist
+    pot_l12m: ctx.results.value_1.pot_l12m
+    pot_100: ctx.results.value_1.pot_100
+    l12m_dctr: ctx.results.value_1.l12m_dctr
+  denominator_label: Eligible
+  callout:
+    hero: "${pot_l12m:,.0f}"
+    sub: "annual revenue upside"
+    tertiary: "Per-account delta: ${delta:,.0f} ({accts_without:,} accounts without debit today)"
+  footer:
+    source: "Source: {client_name} ODD, {month} | DCTR + Reg E modeled at L12M = {l12m_dctr:.0%}"

--- a/docs/slide_specs/value.yml
+++ b/docs/slide_specs/value.yml
@@ -1,0 +1,6 @@
+# value section slide specs.
+# TODO(W3 follow-up): author specs for main-deck slides in this section.
+# Pattern: see docs/slide_specs/_TEMPLATE.yml and docs/slide_specs/dctr.yml.
+# Until specs exist here, deck_builder falls back to today's behavior
+# (analytics-supplied titles), so empty file is safe.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pandas
 pydantic
 pydantic-settings
 python-pptx
+PyYAML
 rich
 uvicorn
 xlsxwriter


### PR DESCRIPTION
## Summary

Wave 3 of the reconciled 4-wave plan. Brings the slide-design system from `SLIDE_DESIGN.md` into executable form: a spec is data, the renderer fills it from `ctx.results`, and the deck builder uses the rendered action title in place of analytics-supplied generic titles.

* `output/slide_spec.py`: YAML loader + renderer (dataclasses, dotted-path resolution, safe-eval expressions, format-map with lenient missing-input handling)
* `docs/slide_specs/dctr.yml`: 3 main-deck specs (DCTR-MAIN-1..3) ported from existing `dctr.md`; `denominator_label` ties to W1 audit law
* `docs/slide_specs/rege.yml`: 2 main-deck specs (REGE-MAIN-1..2) each labeled `Eligible Personal`
* `docs/slide_specs/_TEMPLATE.yml` + 7 section stubs (overview/attrition/mailer/value/insights/competition/txn_exec). Empty file is safe — deck_builder falls back to legacy headlines
* `output/deck_builder.py`: `SlideContent` extended with callout/footer fields; `_result_to_slide` looks up the spec by `slide_id`, renders it, uses the action title
* `requirements.txt`: PyYAML

## What this does **not** do (W3 follow-up)

- Does not yet author specs for the 7 stub sections; that needs domain-specific design decisions on a per-section basis. Stubs in place + template doc the pattern.
- Does not yet rebuild `_build_screenshot_slide` into a full action-slide layout (action title + chart + callout + footer band). Today the spec's action_title overrides the headline; the callout/footer fields land on `SlideContent` but aren't yet rendered as boxes. Follow-up: extend `_build_screenshot_slide` to read the new fields and draw the callout + footer band.

## Test plan

- [x] `pytest tests/` — 64/64 passing (8 new in `test_slide_spec.py`)
- [x] Repo-shipped specs (`dctr.yml`, `rege.yml`) parse and every spec passes the 4-layer-label check
- [ ] On work PC: run an ARS client with DCTR-MAIN-1 in the manifest; confirm the action title in the deck reads as the rendered template (with numbers), not the analytics fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)