### PR TITLE
feat: HTML preview surface for completed runs

### DIFF
--- a/02_Presentations/html_review/from_run_report.py
+++ b/02_Presentations/html_review/from_run_report.py
@@ -1,0 +1,144 @@
+"""Build an HTML review from the persisted run_report.json + charts dir.
+
+The run_report.json (introduced in W4) carries slide_id, title, chart_path,
+and module_id per slide. That's enough to drive html_review.builder without
+needing the live ctx.all_slides list. Lets the UI surface an HTML preview
+for any completed run -- no PowerPoint required.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+from html_review.builder import SECTION_ORDER, build_html
+from html_review.model import ClientMeta
+
+
+_MODULE_TO_SECTION = {
+    "overview": "overview",
+    "stat_codes": "overview",
+    "product_codes": "overview",
+    "eligibility": "overview",
+    "dctr": "dctr",
+    "rege": "rege",
+    "reg_e": "rege",
+    "attrition": "attrition",
+    "value": "value",
+    "mailer": "mailer",
+    "transaction": "transaction",
+    "ics": "ics",
+    "insights": "insights",
+}
+
+
+def _section_for(slide_id: str, module_id: str) -> str:
+    """Best-effort section derivation from slide_id prefix or module_id.
+
+    More specific prefixes (A11, A12, A13, A14) checked before the generic A1
+    overview prefix so VALUE / MAILER routing wins.
+    """
+    sid = (slide_id or "").upper()
+    if sid.startswith("DCTR") or sid.startswith("A7"):
+        return "dctr"
+    if sid.startswith("REGE") or sid.startswith("A8"):
+        return "rege"
+    if sid.startswith("A9") or "ATTRITION" in sid:
+        return "attrition"
+    if sid.startswith("A11") or "VALUE" in sid:
+        return "value"
+    if sid.startswith("A12") or sid.startswith("A13") or sid.startswith("A14") or "MAILER" in sid:
+        return "mailer"
+    if sid.startswith("S") or "INSIGHT" in sid:
+        return "insights"
+    # Overview is the most generic A1 prefix -- check last so A11/A12/etc win.
+    if sid.startswith("A1") or sid.startswith("OVERVIEW"):
+        return "overview"
+    # Fallback to module_id
+    mid = (module_id or "").lower()
+    for token, section in _MODULE_TO_SECTION.items():
+        if mid.startswith(token):
+            return section
+    return "overview"
+
+
+@dataclass
+class _SlideStub:
+    """Duck-typed AnalysisResultLike for html_review.builder."""
+    slide_id: str
+    title: str
+    section: str
+    chart_path: Path | None
+    excel_data: dict[str, Any] | None = None
+    notes: str = ""
+
+
+def build_html_from_run_report(
+    csm: str,
+    month: str,
+    client_id: str,
+    completed_analysis_root: Path,
+    presentations_root: Path,
+    embed_images: bool = True,
+    client_display_name: str = "",
+) -> Path | None:
+    """Build the html_review/index.html for a completed run. Returns path or None.
+
+    Reads run_report.json from `completed_analysis_root/<csm>/<month>/<client_id>/`,
+    writes the HTML to `presentations_root/<csm>/<month>/<client_id>/html_review/`.
+
+    `embed_images=True` inlines every PNG as a base64 data URI so the operator
+    can email the HTML or scp it without dragging the assets folder along.
+    """
+    analysis_dir = completed_analysis_root / csm / month / client_id
+    report_path = analysis_dir / f"{client_id}_{month}_run_report.json"
+    if not report_path.exists():
+        return None
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    raw_slides = payload.get("slides") or []
+    if not raw_slides:
+        return None
+
+    stubs: list[_SlideStub] = []
+    for s in raw_slides:
+        chart = s.get("chart_path") or ""
+        cp = Path(chart) if chart and Path(chart).exists() else None
+        if cp is None and s.get("has_chart"):
+            # Best-effort fallback: look in charts/ for a PNG that contains slide_id
+            sid_token = (s.get("slide_id", "") or "").lower().replace("-", "_").replace(".", "_")
+            if sid_token:
+                for cand in (analysis_dir / "charts").glob("*.png"):
+                    if sid_token in cand.name.lower():
+                        cp = cand
+                        break
+        stubs.append(_SlideStub(
+            slide_id=s.get("slide_id", ""),
+            title=s.get("title", ""),
+            section=_section_for(s.get("slide_id", ""), s.get("module_id", "")),
+            chart_path=cp,
+            excel_data=None,
+            notes=s.get("error", "") or "",
+        ))
+
+    # Month "2026.04" -> "2026-04" / "April 2026"
+    month_dashes = month.replace(".", "-")
+    try:
+        year, mo = month.split(".")
+        month_display = datetime(int(year), int(mo), 1).strftime("%B %Y")
+    except ValueError:
+        month_display = month
+
+    client = ClientMeta(
+        id=client_id,
+        display_name=client_display_name or client_id,
+        month=month_dashes,
+        month_display=month_display,
+        run_date=date.today().isoformat(),
+    )
+
+    out_dir = presentations_root / csm / month / client_id / "html_review"
+    return build_html(stubs, client, out_dir, embed_images=embed_images)

--- a/02_Presentations/html_review/tests/test_from_run_report.py
+++ b/02_Presentations/html_review/tests/test_from_run_report.py
@@ -1,0 +1,140 @@
+"""Tests for from_run_report.build_html_from_run_report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from html_review.from_run_report import build_html_from_run_report, _section_for
+
+
+def _png_bytes() -> bytes:
+    # Minimal valid PNG (1x1 transparent)
+    return (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xfc"
+        b"\xcf\xc0\xf0\x1f\x00\x05\x00\x01\xff\x82\x9a\xb1\xff\x00\x00\x00"
+        b"\x00IEND\xaeB`\x82"
+    )
+
+
+def _stage_run(root: Path, csm: str, month: str, client_id: str):
+    """Stage a fake completed-analysis directory with run_report.json + chart PNG."""
+    analysis_dir = root / csm / month / client_id
+    charts_dir = analysis_dir / "charts"
+    charts_dir.mkdir(parents=True, exist_ok=True)
+
+    png_path = charts_dir / "dctr_1.png"
+    png_path.write_bytes(_png_bytes())
+
+    report_path = analysis_dir / f"{client_id}_{month}_run_report.json"
+    report_path.write_text(json.dumps({
+        "client_id": client_id,
+        "month": month,
+        "summary": {"total": 2, "ok": 1, "failed": 0, "no_chart": 1},
+        "slides": [
+            {
+                "slide_id": "DCTR-1", "module_id": "dctr.penetration",
+                "success": True, "has_chart": True, "has_excel": False,
+                "error": "", "title": "DCTR Overall",
+                "chart_path": str(png_path),
+                "layout_index": 8, "slide_type": "screenshot",
+            },
+            {
+                "slide_id": "REGE-1", "module_id": "rege.status",
+                "success": True, "has_chart": False, "has_excel": False,
+                "error": "", "title": "Reg E Overall",
+                "chart_path": "", "layout_index": 8, "slide_type": "screenshot",
+            },
+        ],
+    }))
+
+
+def test_section_for_routes_known_prefixes():
+    assert _section_for("DCTR-1", "dctr.penetration") == "dctr"
+    assert _section_for("REGE-2", "rege.status") == "rege"
+    assert _section_for("A9.11", "attrition.impact") == "attrition"
+    assert _section_for("A11.1", "value.analysis") == "value"
+    assert _section_for("A12.Jan26", "mailer.response") == "mailer"
+    assert _section_for("S1", "insights.synthesis") == "insights"
+    assert _section_for("A1.1", "overview.eligibility") == "overview"
+
+
+def test_section_for_falls_back_to_overview_on_unknown(tmp_path):
+    assert _section_for("XYZ-1", "unknown_module") == "overview"
+
+
+def test_build_html_returns_none_when_no_report(tmp_path):
+    analysis_root = tmp_path / "analysis"
+    pres_root = tmp_path / "pres"
+    analysis_root.mkdir()
+    out = build_html_from_run_report(
+        csm="Nobody", month="2026.04", client_id="9999",
+        completed_analysis_root=analysis_root,
+        presentations_root=pres_root,
+    )
+    assert out is None
+
+
+def test_build_html_renders_index_for_real_run(tmp_path):
+    analysis_root = tmp_path / "analysis"
+    pres_root = tmp_path / "pres"
+    _stage_run(analysis_root, "TestCSM", "2026.04", "1615")
+
+    out = build_html_from_run_report(
+        csm="TestCSM", month="2026.04", client_id="1615",
+        completed_analysis_root=analysis_root,
+        presentations_root=pres_root,
+        embed_images=True,
+        client_display_name="AcmeCU",
+    )
+    assert out is not None
+    assert out.name == "index.html"
+    assert out.parent.name == "html_review"
+    assert out.parent.parent.name == "1615"
+
+    html = out.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in html
+    assert "AcmeCU" in html
+    # DCTR section should render with the one chart
+    assert "DCTR Overall" in html
+    # Reg E slide has no chart but should still appear in the rege section
+    assert "Reg E Overall" in html
+
+
+def test_build_html_handles_missing_chart_path_with_glob_fallback(tmp_path):
+    """When run_report.json's chart_path is empty but a matching PNG exists in charts/."""
+    analysis_root = tmp_path / "analysis"
+    pres_root = tmp_path / "pres"
+    analysis_dir = analysis_root / "TestCSM" / "2026.04" / "1615"
+    charts_dir = analysis_dir / "charts"
+    charts_dir.mkdir(parents=True, exist_ok=True)
+
+    # File name contains the slide_id token "dctr_1" after normalization
+    png = charts_dir / "dctr_1_overall.png"
+    png.write_bytes(_png_bytes())
+
+    report = analysis_dir / "1615_2026.04_run_report.json"
+    report.write_text(json.dumps({
+        "summary": {},
+        "slides": [{
+            "slide_id": "DCTR-1", "module_id": "dctr",
+            "success": True, "has_chart": True, "has_excel": False,
+            "error": "", "title": "DCTR Overall",
+            "chart_path": "",  # MISSING -- forces fallback
+            "layout_index": 8, "slide_type": "screenshot",
+        }],
+    }))
+
+    out = build_html_from_run_report(
+        csm="TestCSM", month="2026.04", client_id="1615",
+        completed_analysis_root=analysis_root,
+        presentations_root=pres_root,
+        embed_images=True,
+    )
+    assert out is not None
+    # Embedded data-URI confirms the fallback found the PNG
+    html = out.read_text(encoding="utf-8")
+    assert "data:image/png;base64," in html

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -1081,6 +1081,74 @@ async def post_manifest(updates: dict):
     n = write_manifest_decisions(payload)
     resolved = _resolve_manifest_path()
     return {"updated": n, "path": str(resolved) if resolved else None}
+@app.post("/api/preview_html/{csm}/{month}/{client_id}")
+async def post_preview_html(csm: str, month: str, client_id: str):
+    """Build an HTML preview of a completed run and return its URL.
+
+    Reads run_report.json from the analysis dir, walks every (slide_id,
+    chart_path, title) tuple, and renders 02_Presentations/html_review/
+    index.html. Charts are embedded as base64 data URIs so the file is
+    self-contained -- operator can preview without opening PowerPoint.
+
+    Returns: {"ok": True, "html_path": "...", "url": "/preview/..."}
+
+    Requires W4's run_report.json schema (carries chart_path per slide).
+    Pre-W4 runs return 404 with a re-run hint.
+    """
+    import sys as _sys
+    _presentations = str(Path(__file__).resolve().parent.parent / "02_Presentations")
+    if _presentations not in _sys.path:
+        _sys.path.insert(0, _presentations)
+
+    from html_review.from_run_report import build_html_from_run_report
+
+    # COMPLETED_ANALYSIS is `<ARS_BASE>/01_Analysis/01_Completed_Analysis`,
+    # PRESENTATIONS_BASE is `<ARS_BASE>/02_Presentations`. The helper takes
+    # the per-stage *parents* (the level above the per-CSM folder) so it can
+    # resolve `<root>/<csm>/<month>/<client_id>` consistently.
+    analysis_root = COMPLETED_ANALYSIS
+    pres_root = PRESENTATIONS_BASE
+
+    clients = load_clients_config().get("clients", {})
+    client_display = clients.get(client_id, {}).get("ClientName", client_id)
+
+    try:
+        html_path = build_html_from_run_report(
+            csm=csm, month=month, client_id=client_id,
+            completed_analysis_root=analysis_root,
+            presentations_root=pres_root,
+            embed_images=True,
+            client_display_name=client_display,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"HTML preview build failed: {exc}") from exc
+
+    if html_path is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Run report not found -- re-run analysis to regenerate.",
+        )
+
+    return {
+        "ok": True,
+        "html_path": str(html_path),
+        "url": f"/preview/{csm}/{month}/{client_id}/",
+    }
+
+
+@app.get("/preview/{csm}/{month}/{client_id}/")
+async def get_preview_root(csm: str, month: str, client_id: str):
+    """Serve the previously-built html_review/index.html for inline viewing.
+
+    Loadable directly in a new tab or iframe-embedded by the UI. Returns 404
+    if the preview hasn't been built yet -- caller should POST /api/preview_html
+    first.
+    """
+    pres_root = PRESENTATIONS_BASE
+    target = pres_root / csm / month / client_id / "html_review" / "index.html"
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="Preview not built; POST /api/preview_html first")
+    return FileResponse(target, media_type="text/html")
 
 
 @app.get("/api/download")

--- a/05_UI/index.html
+++ b/05_UI/index.html
@@ -799,6 +799,8 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
                 <option value="">Select a client...</option>
             </select>
             <button class="btn btn-dark" onclick="openDeckShapeEditor()" style="font-size:12px;padding:8px 16px;">Deck Shape</button>
+            <button class="btn btn-dark" onclick="openHtmlPreview()"
+                style="font-size:12px;padding:8px 16px;">Preview as HTML</button>
         </div>
     </div>
 
@@ -840,6 +842,29 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
                 <tbody id="deckShapeRows"></tbody>
             </table>
         </div>
+    </div>
+
+    <!-- HTML preview surface. Iframe loads /preview/<csm>/<month>/<client_id>/.
+         Built on demand by POST /api/preview_html which calls
+         02_Presentations/html_review.from_run_report.build_html_from_run_report. -->
+    <div id="htmlPreviewPanel" style="display:none;margin-bottom:24px;
+        border:2px solid var(--border);border-radius:12px;background:var(--card);
+        padding:14px 18px;">
+        <div style="display:flex;justify-content:space-between;align-items:baseline;
+            margin-bottom:10px;">
+            <div>
+                <div style="font-weight:700;font-size:15px;color:var(--dark);">HTML Preview</div>
+                <div id="htmlPreviewSub" style="font-size:12px;color:var(--muted);">--</div>
+            </div>
+            <div style="display:flex;gap:8px;">
+                <button class="btn" onclick="openHtmlPreviewInNewTab()"
+                    style="font-size:12px;padding:6px 14px;">Open in new tab</button>
+                <button class="btn btn-dark" onclick="document.getElementById('htmlPreviewPanel').style.display='none'"
+                    style="font-size:12px;padding:6px 14px;">Close</button>
+            </div>
+        </div>
+        <iframe id="htmlPreviewFrame" src="" frameborder="0"
+            style="width:100%;height:75vh;border:1px solid var(--border);border-radius:8px;background:#fff;"></iframe>
     </div>
 
     <div id="resultsViewer" style="display:none;">
@@ -1882,6 +1907,50 @@ async function loadDownloads(csm, month, clientId) {
         dlGrid.classList.add('visible');
     } catch(e) {
         console.error('Failed to load downloads:', e);
+    }
+}
+
+// HTML preview surface for completed runs. Builds an embedded version of
+// the html_review/index.html from the persisted run_report.json + chart PNGs.
+let _htmlPreviewState = {csm: '', month: '', clientId: '', url: ''};
+
+async function openHtmlPreview() {
+    const csm = document.getElementById('gCsmSel')?.value;
+    const month = document.getElementById('gMonthSel')?.value;
+    const clientSel = document.getElementById('rClientSel');
+    const clientId = clientSel?.value;
+    if (!csm || !month || !clientId) {
+        alert('Pick a CSM + period on the Generate tab and a client on the Results tab first.');
+        return;
+    }
+    const panel = document.getElementById('htmlPreviewPanel');
+    const sub = document.getElementById('htmlPreviewSub');
+    const frame = document.getElementById('htmlPreviewFrame');
+    panel.style.display = '';
+    sub.textContent = `Building preview for ${clientId} (${csm} / ${month})...`;
+    frame.src = 'about:blank';
+    try {
+        const r = await fetch(
+            `/api/preview_html/${encodeURIComponent(csm)}/${encodeURIComponent(month)}/${encodeURIComponent(clientId)}`,
+            {method: 'POST', headers: {'Content-Type': 'application/json'}}
+        );
+        if (!r.ok) {
+            const t = await r.text();
+            sub.textContent = 'Preview build failed: ' + t;
+            return;
+        }
+        const data = await r.json();
+        _htmlPreviewState = {csm, month, clientId, url: data.url};
+        sub.innerHTML = `Served from <code>${data.html_path}</code>`;
+        frame.src = data.url;
+    } catch (err) {
+        sub.textContent = 'Preview error: ' + err.message;
+    }
+}
+
+function openHtmlPreviewInNewTab() {
+    if (_htmlPreviewState.url) {
+        window.open(_htmlPreviewState.url, '_blank');
     }
 }
 


### PR DESCRIPTION
## Summary

Operators can now preview a completed run as HTML inside the UI — no PowerPoint required. New Results-tab button builds + serves an iframe-embedded preview of every slide.

* `02_Presentations/html_review/from_run_report.py` — adapter that reads the persisted `run_report.json` + `charts/*.png` and feeds them to the existing `html_review.builder`. Embeds PNGs as base64 data URIs so the output is self-contained.
* `POST /api/preview_html/{csm}/{month}/{client_id}` builds on demand
* `GET /preview/{csm}/{month}/{client_id}/` serves the built HTML for inline iframe loading
* Results tab gets a "Preview as HTML" button + collapsible iframe panel with "Open in new tab" / "Close" controls

## Dependencies

- Best with W4 #164 merged first (W4 persisted `chart_path` to `run_report.json`). Without it, the endpoint falls back to a glob search in `charts/` for a PNG whose name contains the normalized slide_id token — covers most cases but the explicit `chart_path` is more reliable.

## Test plan

- [x] `pytest html_review/tests/` — 5 new tests pass; backend suite 56/56 untouched
- [ ] On work PC after merge: open Results tab → select a client → click **Preview as HTML** → iframe should load with every slide rendered as `<img>` + title + section heading
- [ ] Click **Open in new tab** → standalone preview tab opens
- [ ] Resize browser → iframe stays at 75vh

🤖 Generated with [Claude Code](https://claude.com/claude-code)