### PR TITLE
feat(txn): TXN-results adapter + competition + txn_exec specs

### DIFF
--- a/01_Analysis/00-Scripts/analytics/txn_exports.py
+++ b/01_Analysis/00-Scripts/analytics/txn_exports.py
@@ -1,0 +1,90 @@
+"""Declarations of which variables each TXN script exposes to ctx.results.
+
+Each entry maps a (section, script_number) tuple to a list of namespace
+variable names that the TXN-results adapter copies into
+`ctx.results[f"{section}_{script_number}"]["insights"]` after the script runs.
+
+Schema:
+    SECTION_EXPORTS[(section, script_number)] = {
+        "insights": ["var_name", ...],  # bare scalars / strings the slide spec reads
+        "tables":   ["var_name", ...],  # DataFrames (rarely surfaced in headlines)
+    }
+
+Variables that aren't in the namespace when the adapter runs are silently
+skipped (logged at DEBUG). That lets a partially-implemented script survive
+without breaking the adapter -- the slide spec falls back to its lenient
+placeholder behavior.
+
+To add a new export:
+1. Find the TXN script (e.g. analytics/competition/13_threat_quadrant.py).
+2. Identify the bare variable in its namespace that holds the value you want.
+3. Add an entry below; the key is (section_name, script_number).
+
+To rename a TXN script: rename only -- don't renumber. The script number is
+the registry's stable key.
+
+See docs/txn-results-adapter-design.md for the full design rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Per-script export declarations.
+# Empty lists are placeholders for known-interesting scripts whose namespace
+# variables haven't been wired yet -- the registry doubles as a TODO list.
+SECTION_EXPORTS: dict[tuple[str, int], dict[str, list[str]]] = {
+    # competition section
+    (
+        "competition",
+        13,
+    ): {  # 13_threat_quadrant.py -- "who's eating our card spend"
+        "insights": [
+            "top_competitor",     # str: top out-of-network spender by share
+            "top_share",          # float 0..1: top competitor's share
+            "second_competitor",
+            "second_share",
+            "threat_count",       # int: competitors above the threshold
+        ],
+        "tables": ["threat_quadrant_df"],
+    },
+    (
+        "competition",
+        24,
+    ): {  # 24_segment_heatmap.py -- wallet-share by segment
+        "insights": [
+            "wallet_share_pct",     # float 0..1
+            "wallet_gap_dollars",   # float: annualized leakage estimate
+        ],
+        "tables": ["segment_heatmap_df"],
+    },
+
+    # executive section (TXN executive scorecard + action roadmap)
+    (
+        "executive",
+        1,
+    ): {  # 01_kpi_scorecard.py -- top-of-deck portfolio KPIs
+        "insights": [
+            "total_active_accounts",
+            "total_swipes",
+            "total_spend",
+            "avg_spend_per_account",
+            "interchange_revenue",
+        ],
+    },
+    (
+        "executive",
+        5,
+    ): {  # 05_action_roadmap.py -- prioritized initiatives
+        "insights": [
+            "n_actions",
+            "total_impact",
+            "top_action",
+        ],
+    },
+}
+
+
+def get_exports(section: str, script_number: int) -> dict[str, list[str]] | None:
+    """Return the export declaration for one script, or None if not registered."""
+    return SECTION_EXPORTS.get((section, script_number))

--- a/01_Analysis/00-Scripts/analytics/txn_wrapper.py
+++ b/01_Analysis/00-Scripts/analytics/txn_wrapper.py
@@ -118,10 +118,77 @@ class ScriptFailure:
     error_msg: str
 
 
+# ---------------------------------------------------------------------------
+# TXN-results adapter (docs/txn-results-adapter-design.md)
+# ---------------------------------------------------------------------------
+
+
+def _extract_script_number(filename: str) -> int | None:
+    """01_foo.py -> 1; 70_banking_vs_ecosystems.py -> 70; unprefixed -> None."""
+    stem = filename.rsplit(".", 1)[0]
+    head = stem.split("_", 1)[0]
+    try:
+        return int(head)
+    except (TypeError, ValueError):
+        return None
+
+
+def expose_to_ctx_results(
+    ctx: PipelineContext | None,
+    namespace: dict[str, Any],
+    section: str,
+    script_number: int,
+    script_path: Path,
+) -> None:
+    """Copy declared exports from `namespace` into ctx.results.
+
+    Called after each TXN script finishes execution. Looks up
+    (section, script_number) in SECTION_EXPORTS; for every variable name
+    declared, reads it from the namespace and stamps it on
+    ctx.results[f"{section}_{script_number}"]. Silently skips variables
+    that aren't in the namespace -- they may not exist if the script
+    failed partway through.
+
+    No-op when ctx is None (e.g. txn_setup runs with a stub ctx).
+    """
+    if ctx is None:
+        return
+    try:
+        from ars_analysis.analytics.txn_exports import get_exports
+    except Exception:
+        return
+
+    spec = get_exports(section, script_number)
+    if spec is None:
+        return  # No declared exports -- not an error.
+
+    key = f"{section}_{script_number}"
+    if not hasattr(ctx, "results") or ctx.results is None:
+        return
+    bucket = ctx.results.setdefault(key, {})
+    bucket.setdefault("insights", {})
+    bucket.setdefault("tables", {})
+    bucket["script"] = script_path.name
+
+    for var in spec.get("insights", []):
+        if var in namespace:
+            bucket["insights"][var] = namespace[var]
+        else:
+            logger.debug(
+                "TXN export miss: {section}/{n} expected '{var}' not in namespace",
+                section=section, n=script_number, var=var,
+            )
+
+    for var in spec.get("tables", []):
+        if var in namespace:
+            bucket["tables"][var] = namespace[var]
+
+
 def _execute_scripts(script_dir: Path, namespace: dict[str, Any],
                      chart_dir: Path, section_prefix: str,
                      section_recorder: object = None,
                      manifest_meta: dict[str, str] | None = None,
+                     ctx: PipelineContext | None = None,
                      ) -> tuple[list[Path], list[ScriptFailure]]:
     """Execute all .py scripts in a directory in sorted order, sharing a namespace.
 
@@ -184,6 +251,15 @@ def _execute_scripts(script_dir: Path, namespace: dict[str, Any],
                 code = script_path.read_text(encoding="utf-8")
                 namespace["__file__"] = str(script_path)
                 exec(compile(code, str(script_path), "exec"), namespace)
+                # TXN-results adapter: after the script settles, copy any
+                # declared variables out of the shared namespace into
+                # ctx.results so the slide_spec renderer can bind to them.
+                # See docs/txn-results-adapter-design.md + analytics/txn_exports.py.
+                _script_number = _extract_script_number(script_path.name)
+                if _script_number is not None and ctx is not None:
+                    expose_to_ctx_results(
+                        ctx, namespace, section_prefix, _script_number, script_path,
+                    )
             except Exception as exc:
                 _failed = True
                 logger.error("  TXN script failed: {name}: {err}", name=script_name, err=exc)
@@ -341,6 +417,7 @@ class TXNSectionWrapper(AnalysisModule):
                 logger.info("  Running txn_setup...")
                 _setup_charts, _setup_failures = _execute_scripts(
                     setup_dir, namespace, ctx.paths.charts_dir, "txn_setup",
+                    ctx=ctx,
                 )
                 if _setup_failures:
                     logger.error(
@@ -364,6 +441,7 @@ class TXNSectionWrapper(AnalysisModule):
             charts, self.failures = _execute_scripts(
                 self.section_dir, namespace, chart_dir, self.section_name,
                 section_recorder=_recorder, manifest_meta=_manifest_meta,
+                ctx=ctx,
             )
             # Record slide count + flag if zero slides on a section that expected them
             if _mf is not None and _recorder is not None:
@@ -638,6 +716,7 @@ def prepare_shared_namespace(ctx: PipelineContext) -> dict[str, Any]:
     logger.info("Running txn_setup once for all sections...")
     _charts, setup_failures = _execute_scripts(
         setup_dir, namespace, ctx.paths.charts_dir, "txn_setup",
+        ctx=ctx,
     )
     if setup_failures:
         # txn_setup failures are CRITICAL -- combined_df may not exist and

--- a/01_Analysis/00-Scripts/tests/test_txn_adapter.py
+++ b/01_Analysis/00-Scripts/tests/test_txn_adapter.py
@@ -1,0 +1,123 @@
+"""Tests for the TXN-results adapter (txn_wrapper.expose_to_ctx_results)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_SCRIPTS_DIR))
+if "ars_analysis" not in sys.modules:
+    _pkg = types.ModuleType("ars_analysis")
+    _pkg.__path__ = [str(_SCRIPTS_DIR)]
+    sys.modules["ars_analysis"] = _pkg
+
+from ars_analysis.analytics.txn_exports import SECTION_EXPORTS, get_exports
+from ars_analysis.analytics.txn_wrapper import (
+    _extract_script_number,
+    expose_to_ctx_results,
+)
+
+
+@dataclass
+class _StubCtx:
+    """Minimal duck-typed PipelineContext for adapter tests."""
+    results: dict = field(default_factory=dict)
+
+
+def test_extract_script_number_handles_standard_names():
+    assert _extract_script_number("01_kpi_scorecard.py") == 1
+    assert _extract_script_number("13_threat_quadrant.py") == 13
+    assert _extract_script_number("70_banking_vs_ecosystems.py") == 70
+
+
+def test_extract_script_number_returns_none_for_unprefixed():
+    assert _extract_script_number("competitor_config.py") is None
+    assert _extract_script_number("foo.py") is None
+
+
+def test_get_exports_returns_competition_13_entry():
+    exports = get_exports("competition", 13)
+    assert exports is not None
+    assert "top_competitor" in exports["insights"]
+    assert "top_share" in exports["insights"]
+    assert "threat_quadrant_df" in exports["tables"]
+
+
+def test_get_exports_returns_none_for_unregistered_script():
+    assert get_exports("competition", 999) is None
+    assert get_exports("nonexistent_section", 1) is None
+
+
+def test_expose_to_ctx_results_copies_declared_variables():
+    ctx = _StubCtx()
+    namespace = {
+        "top_competitor": "Big National Bank",
+        "top_share": 0.27,
+        "second_competitor": "Mega CU",
+        "second_share": 0.18,
+        "threat_count": 12,
+        "threat_quadrant_df": "<DataFrame stand-in>",
+        "irrelevant_var": "should not be copied",
+    }
+    expose_to_ctx_results(
+        ctx, namespace, "competition", 13, Path("13_threat_quadrant.py")
+    )
+    bucket = ctx.results["competition_13"]
+    assert bucket["script"] == "13_threat_quadrant.py"
+    assert bucket["insights"]["top_competitor"] == "Big National Bank"
+    assert bucket["insights"]["top_share"] == 0.27
+    assert bucket["insights"]["threat_count"] == 12
+    assert bucket["tables"]["threat_quadrant_df"] == "<DataFrame stand-in>"
+    # Vars not in the export registry don't leak in
+    assert "irrelevant_var" not in bucket["insights"]
+
+
+def test_expose_to_ctx_results_silently_skips_missing_namespace_vars():
+    """Partially-failed scripts shouldn't break the adapter."""
+    ctx = _StubCtx()
+    namespace = {"top_competitor": "BigBank"}  # missing top_share, threat_count
+    expose_to_ctx_results(ctx, namespace, "competition", 13, Path("13_foo.py"))
+    bucket = ctx.results["competition_13"]
+    assert bucket["insights"] == {"top_competitor": "BigBank"}
+    # No KeyError on missing vars
+
+
+def test_expose_to_ctx_results_noop_when_no_registry_entry():
+    """Unregistered (section, script_n) tuples are silently ignored."""
+    ctx = _StubCtx()
+    expose_to_ctx_results(ctx, {"some_var": 1}, "competition", 999, Path("999_x.py"))
+    assert ctx.results == {}
+
+
+def test_expose_to_ctx_results_noop_when_ctx_is_none():
+    """txn_setup runs without a usable ctx -- the adapter must tolerate it."""
+    # Should not raise
+    expose_to_ctx_results(None, {"top_competitor": "x"}, "competition", 13, Path("13.py"))
+
+
+def test_executive_exports_registered():
+    """Both executive scorecard + roadmap need export declarations."""
+    assert get_exports("executive", 1) is not None
+    assert "interchange_revenue" in get_exports("executive", 1)["insights"]
+    assert get_exports("executive", 5) is not None
+    assert "top_action" in get_exports("executive", 5)["insights"]
+
+
+def test_section_exports_keys_are_well_formed():
+    """Every registry entry has a (str, int) key and dict value."""
+    for key, value in SECTION_EXPORTS.items():
+        assert isinstance(key, tuple) and len(key) == 2
+        assert isinstance(key[0], str) and key[0]
+        assert isinstance(key[1], int) and key[1] > 0
+        assert isinstance(value, dict)
+        # Insights / tables, both optional but if present must be list[str]
+        for field_name in ("insights", "tables"):
+            if field_name in value:
+                assert isinstance(value[field_name], list)
+                for v in value[field_name]:
+                    assert isinstance(v, str) and v

--- a/docs/slide_specs/competition.yml
+++ b/docs/slide_specs/competition.yml
@@ -1,13 +1,47 @@
-# Competition section slide specs.
+# Competition section slide specs (TXN section).
 #
-# DEFERRED: Competition is a TXN section. Its modules are numbered scripts
-# (01_competitor_config.py through 70_banking_vs_ecosystems.py) that produce
-# Plotly charts directly without populating ctx.results in the dict shape the
-# slide_spec renderer binds to. Authoring specs here first needs a thin
-# TXN-section results adapter (per-script insights -> ctx.results["competition_<id>"]).
+# Wiring: depends on the TXN-results adapter (analytics/txn_exports.py +
+# txn_wrapper.expose_to_ctx_results). After each numbered script runs, its
+# declared variables are copied into ctx.results[f"{section}_{script_number}"].
+# Specs below bind to those keys directly.
 #
-# Roadmap: when txn_setup is extended to expose per-script insights dicts,
-# add specs for COMPETITION-MAIN-THREAT-QUADRANT (slide 13_threat_quadrant)
-# and COMPETITION-MAIN-WALLET-SHARE (24_segment_heatmap derivative). Until
-# then, deck_builder falls back to today's behavior (Plotly-rendered titles),
-# so this empty file is safe.
+# slide_id format follows txn_wrapper's auto-generated TXN-{section}-{n}
+# scheme (where n is chart order, NOT script number). The action title +
+# callout reach into ctx.results with explicit script_number keys so the
+# two indexes stay decoupled.
+#
+# Per the 4-layer law: competition rates anchor to the Eligible base.
+# All dollar figures derive from the Eligible Mailable spend window.
+
+TXN-competition-13:
+  layout: TWO_CONTENT
+  components: [13_threat_quadrant]
+  action_title: "{top_competitor} captures {top_share:.0%} of out-of-network spend; {threat_count} competitors above threshold"
+  inputs:
+    top_competitor:    ctx.results.competition_13.insights.top_competitor
+    top_share:         ctx.results.competition_13.insights.top_share
+    second_competitor: ctx.results.competition_13.insights.second_competitor
+    second_share:      ctx.results.competition_13.insights.second_share
+    threat_count:      ctx.results.competition_13.insights.threat_count
+  denominator_label: Eligible
+  callout:
+    hero: "{top_share:.0%}"
+    sub: "share captured by top competitor"
+    tertiary: "{threat_count} competitors above threshold are draining card spend"
+  footer:
+    source: "Source: {client_name} TXN, {month} | competition module / threat quadrant"
+
+TXN-competition-24:
+  layout: TWO_CONTENT
+  components: [24_segment_heatmap]
+  action_title: "Estimated ${wallet_gap_dollars:,.0f} in addressable card-spend leakage"
+  inputs:
+    wallet_share_pct:   ctx.results.competition_24.insights.wallet_share_pct
+    wallet_gap_dollars: ctx.results.competition_24.insights.wallet_gap_dollars
+  denominator_label: Eligible
+  callout:
+    hero: "${wallet_gap_dollars:,.0f}"
+    sub: "annual leakage opportunity"
+    tertiary: "Current wallet share: {wallet_share_pct:.0%}"
+  footer:
+    source: "Source: {client_name} TXN, {month} | wallet-share heatmap derivation"

--- a/docs/slide_specs/txn_exec.yml
+++ b/docs/slide_specs/txn_exec.yml
@@ -1,9 +1,41 @@
-# Transaction executive scorecard slide specs.
+# Transaction executive scorecard slide specs (TXN section).
 #
-# DEFERRED: Same as competition -- TXN sections use numbered scripts
-# (e.g. analytics/executive/01_*.py..05_action_roadmap.py) without ctx.results
-# dict population. Wiring specs here first needs the same TXN-results adapter.
+# Wiring: depends on the TXN-results adapter. analytics/executive/01_*.py and
+# 05_action_roadmap.py expose their KPIs / action lists via
+# analytics/txn_exports.py.
 #
-# Roadmap: when the adapter lands, author TXN-EXEC-MAIN-1 (executive KPI
-# scorecard, sourced from executive/01..04) and TXN-EXEC-MAIN-2 (action
-# roadmap from executive/05_action_roadmap.py).
+# Per the 4-layer law: TXN KPI rates anchor to the Eligible base.
+
+TXN-executive-1:
+  layout: TWO_CONTENT
+  components: [01_kpi_scorecard]
+  action_title: "{total_active_accounts:,} active accounts; ${total_spend:,.0f} swiped; ${interchange_revenue:,.0f} interchange"
+  inputs:
+    total_active_accounts: ctx.results.executive_1.insights.total_active_accounts
+    total_swipes:          ctx.results.executive_1.insights.total_swipes
+    total_spend:           ctx.results.executive_1.insights.total_spend
+    avg_spend_per_account: ctx.results.executive_1.insights.avg_spend_per_account
+    interchange_revenue:   ctx.results.executive_1.insights.interchange_revenue
+  denominator_label: Eligible
+  callout:
+    hero: "${interchange_revenue:,.0f}"
+    sub: "interchange revenue captured"
+    tertiary: "Avg ${avg_spend_per_account:,.0f} spend per account"
+  footer:
+    source: "Source: {client_name} TXN, {month} | executive scorecard"
+
+TXN-executive-5:
+  layout: TWO_CONTENT
+  components: [05_action_roadmap]
+  action_title: "{n_actions} prioritized initiatives totaling ${total_impact:,.0f} in modeled annual impact"
+  inputs:
+    n_actions:    ctx.results.executive_5.insights.n_actions
+    total_impact: ctx.results.executive_5.insights.total_impact
+    top_action:   ctx.results.executive_5.insights.top_action
+  denominator_label: Eligible
+  callout:
+    hero: "${total_impact:,.0f}"
+    sub: "modeled annual impact"
+    tertiary: "Lead with: {top_action}"
+  footer:
+    source: "Source: {client_name} TXN, {month} | initiatives from executive roadmap"


### PR DESCRIPTION
## Summary

Implements the TXN-results adapter designed in #168 and ships the two spec files that depend on it. Closes the last named blocker from the W3 follow-up doc.

* `analytics/txn_exports.py` — per-script export registry. `(section, script_n)` → declared namespace variables to copy into `ctx.results`. Initial coverage: `competition_13`, `competition_24`, `executive_1`, `executive_5`.
* `analytics/txn_wrapper.py` — new `expose_to_ctx_results()` adapter + `_extract_script_number()` helper. Hooks into `_execute_scripts` after each script's body returns. Silently skips missing variables (partial-failure tolerant). No-op when `ctx=None` (txn_setup phase).
* `docs/slide_specs/competition.yml` — `TXN-competition-13` (threat quadrant) + `TXN-competition-24` (wallet share). Anchored to Eligible.
* `docs/slide_specs/txn_exec.yml` — `TXN-executive-1` (KPI scorecard) + `TXN-executive-5` (action roadmap). Anchored to Eligible.

## Design decisions from #168 settled

1. **Registry location:** `analytics/txn_exports.py` (project state)
2. **Renumbering:** forbidden (documented). Rename freely
3. **Slide_id contract:** keep `TXN-{section}-{chart_index}` format; YAML specs use explicit `ctx.results.{section}_{script_n}` paths for decoupling
4. **Missing-input behavior:** existing lenient placeholder via `_format` — no separate failure path

## Dependencies

- Best with **W3 #163** merged first (provides the slide_spec system that consumes these YAML files). Conflicts with the W3 stubs for `competition.yml` + `txn_exec.yml` — resolution at merge: take this PR's version.
- Adapter call sites can land independently — they no-op when no registry entry exists.

## Test plan

- [x] `pytest tests/` — 66/66 passing (10 new in `test_txn_adapter.py`)
- [ ] On work PC after merge: run a TXN-product client. Confirm `ctx.results["competition_13"]["insights"]["top_competitor"]` gets populated (log at DEBUG to verify; or inspect via `print` in a draft commit).
- [ ] Confirm the TXN deck's competition + executive main-deck slides now show action-title sentences with numbers from the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)