### PR TITLE
feat(w1): expand audit registry + stamp key AnalysisResults

### DIFF
--- a/01_Analysis/00-Scripts/analytics/attrition/rates.py
+++ b/01_Analysis/00-Scripts/analytics/attrition/rates.py
@@ -122,6 +122,8 @@ def _overall(ctx: PipelineContext) -> list[AnalysisResult]:
             title="Overall Attrition Rate",
             chart_path=chart_path,
             notes=(f"{overall_rate:.1%} overall ({n_closed:,}/{total:,}), L12M: {l12m_rate:.1%}"),
+            denominator_label="Eligible",
+            denominator_n=int(total or 0),
         )
     ]
 

--- a/01_Analysis/00-Scripts/analytics/dctr/penetration.py
+++ b/01_Analysis/00-Scripts/analytics/dctr/penetration.py
@@ -264,6 +264,8 @@ class DCTRPenetration(AnalysisModule):
                     f"Recent: {ins['recent_dctr']:.1%} | "
                     f"Accounts: {ins['total_accounts']:,}"
                 ),
+                denominator_label="Eligible",
+                denominator_n=int(ins.get("total_accounts") or 0),
             )
         ]
 
@@ -315,6 +317,11 @@ class DCTRPenetration(AnalysisModule):
                 title="Debit Card Take Rate: Open vs Eligible",
                 excel_data={"Comparison": comparison},
                 notes=f"Open: {open_ins['overall_dctr']:.1%} | Eligible: {hist_ins['overall_dctr']:.1%} | Gap: {diff:+.1%}",
+                # DCTR-2 is the methodology slide -- the ONLY slide where Open is
+                # legitimately the primary denominator framing. Audit's
+                # OPEN_ALLOWLIST whitelists it.
+                denominator_label="Open",
+                denominator_n=int(len(oa) or 0),
             )
         ]
 
@@ -358,6 +365,8 @@ class DCTRPenetration(AnalysisModule):
                 chart_path=chart_path,
                 excel_data={"Monthly": monthly},
                 notes=f"L12M: {l12m_ins['dctr']:.1%} ({l12m_ins['total_accounts']:,} accts) | vs Overall: {comp:+.1%}",
+                denominator_label="Eligible",
+                denominator_n=int(l12m_ins.get("total_accounts") or 0),
             )
         ]
 

--- a/01_Analysis/00-Scripts/analytics/rege/status.py
+++ b/01_Analysis/00-Scripts/analytics/rege/status.py
@@ -194,6 +194,8 @@ class RegEStatus(AnalysisModule):
                 chart_path=chart_path,
                 excel_data={"Summary": summary},
                 notes=notes,
+                denominator_label="Eligible Personal",
+                denominator_n=int(t_all or 0),
             )
         ]
 

--- a/01_Analysis/00-Scripts/analytics/value/analysis.py
+++ b/01_Analysis/00-Scripts/analytics/value/analysis.py
@@ -430,6 +430,9 @@ class ValueAnalysis(AnalysisModule):
                 chart_path=chart_path,
                 excel_data={"Comparison": comp_df},
                 notes=notes,
+                # Value figures derive from DCTR-based rate gaps -- Eligible.
+                denominator_label="Eligible",
+                denominator_n=int((aw or 0) + (awo or 0)),
             )
         ]
 

--- a/01_Analysis/00-Scripts/pipeline/steps/audit.py
+++ b/01_Analysis/00-Scripts/pipeline/steps/audit.py
@@ -37,33 +37,80 @@ OPEN_ALLOWLIST: frozenset[str] = frozenset((
 
 # Default denominator label per slide_id prefix. Modules can override by stamping
 # `denominator_label` on the AnalysisResult directly.
+#
+# Ordering matters: more specific prefixes are listed first so they win over
+# more general ones (A11, A12, A13, A14 must beat A1). _default_label sorts
+# the prefixes by descending length at lookup time to enforce this.
 DEFAULT_BY_PREFIX: dict[str, str] = {
-    "dctr_": "Eligible",
-    "DCTR-": "Eligible",
-    "rege_": "Eligible Personal",
-    "REGE-": "Eligible Personal",
-    "reg_e_": "Eligible Personal",
-    "attrition_": "Eligible",
-    "A9": "Eligible",
+    # DCTR section
+    "dctr_":     "Eligible",
+    "DCTR-":     "Eligible",
+    "A7":        "Eligible",            # A7.1, A7.2, A7.3, A7.6a, A7 combo
+
+    # Reg E section -- inherently personal-only by regulation
+    "rege_":     "Eligible Personal",
+    "REGE-":     "Eligible Personal",
+    "reg_e_":    "Eligible Personal",
+    "A8":        "Eligible Personal",   # A8.1, A8.2, A8.3, A8.12
+
+    # Attrition section
+    "attrition_":   "Eligible",
+    "ATTRITION-":   "Eligible",         # W3 spec slide IDs (ATTRITION-MAIN-1)
+    "A9":           "Eligible",         # A9.1, A9.2, A9.11
+
+    # Value section
+    "value_":  "Eligible",
+    "VALUE-":  "Eligible",              # W3 spec slide IDs (VALUE-MAIN-1)
+    "A11":     "Eligible",              # A11.1, A11.2
+
+    # Mailer section -- response rates anchor to Eligible (mailable subset is
+    # numerator framing, not denominator narrowing)
     "mailer_": "Eligible",
-    "value_": "Eligible",
-    "A11": "Eligible",
+    "A12":     "Eligible",
+    "A13":     "Eligible",
+    "A14":     "Eligible",
+    "A16":     "Eligible",           # cohort spend trajectories
+
+    # Insights / S-slides
     "insights_": "Eligible",
-    "S1": "Eligible",
-    "S6": "Eligible",
-    "S8": "Eligible",
+    "INSIGHTS-": "Eligible",            # W3 spec slide IDs (INSIGHTS-MAIN-1)
+    "S1":        "Eligible",         # revenue gap
+    "S2":        "Eligible",         # uplift
+    "S3":        "Eligible",
+    "S4":        "Eligible",
+    "S5":        "Eligible",
+    "S6":        "Eligible",         # opportunity map
+    "S7":        "Eligible",
+    "S8":        "Eligible",         # action plan
+    "impact_s":  "Eligible",         # ctx.results key style
+
+    # Branch scorecard (insights/branch_scorecard.py)
     "branch_scorecard": "Eligible",
-    "a19_": "Eligible",
+    "a19_":             "Eligible",
+
+    # Overview / A1.x intro slides
     "overview_": "Eligible",
-    "A1": "Eligible",
+    "OVERVIEW-": "Eligible",            # W3 spec slide IDs (OVERVIEW-MAIN-1)
+    "A1":        "Eligible",            # A1, A1.1, A1.2 (sort-by-length picks A11 first)
+
+    # Mailer W3 spec IDs
+    "MAILER-":   "Eligible",
+
+    # TXN spec slide IDs from #169
+    "TXN-":      "Eligible",
 }
 
 
 def _default_label(slide_id: str) -> str:
-    """Infer the default denominator label for a slide_id when modules haven't stamped one."""
-    for prefix, label in DEFAULT_BY_PREFIX.items():
+    """Infer the default denominator label for a slide_id when modules haven't stamped one.
+
+    Walks the registry in descending-prefix-length order so specific prefixes
+    (e.g. 'A11') win over generic ones (e.g. 'A1').
+    """
+    sorted_prefixes = sorted(DEFAULT_BY_PREFIX.keys(), key=len, reverse=True)
+    for prefix in sorted_prefixes:
         if slide_id.startswith(prefix):
-            return label
+            return DEFAULT_BY_PREFIX[prefix]
     return ""
 
 

--- a/01_Analysis/00-Scripts/tests/test_audit.py
+++ b/01_Analysis/00-Scripts/tests/test_audit.py
@@ -65,6 +65,37 @@ def test_default_label_unknown_returns_empty():
     assert _default_label("unknown_slide_xyz") == ""
 
 
+def test_default_label_specific_prefix_beats_generic():
+    # Original bug: 'A1' would match 'A11.1' before 'A11' got a chance.
+    # _default_label sorts prefixes by descending length to prevent that.
+    assert _default_label("A11.1") == "Eligible"   # value, not overview
+    assert _default_label("A12.Jan26") == "Eligible"  # mailer aggregate
+    assert _default_label("A13.Agg") == "Eligible"
+    assert _default_label("A14.1") == "Eligible"   # mailer reach
+    assert _default_label("A1.1") == "Eligible"   # overview still resolves
+    assert _default_label("A1") == "Eligible"
+
+
+def test_a8_prefix_resolves_to_eligible_personal():
+    """Reg E A8.x slides should all anchor to Eligible Personal per the law."""
+    for sid in ("A8.1", "A8.2", "A8.3", "A8.12"):
+        assert _default_label(sid) == "Eligible Personal"
+
+
+def test_a7_prefix_resolves_to_eligible():
+    """DCTR A7.x slides should all anchor to Eligible."""
+    for sid in ("A7.1", "A7.2", "A7.3", "A7.6a"):
+        assert _default_label(sid) == "Eligible"
+
+
+def test_default_label_covers_authored_spec_slides():
+    """Every section authored in W3 specs should resolve to a 4-layer label."""
+    valid = {"Eligible", "Eligible Personal", "Eligible Business", "Open"}
+    for sid in ("DCTR-MAIN-1", "REGE-MAIN-1", "OVERVIEW-MAIN-1",
+                "ATTRITION-MAIN-1", "VALUE-MAIN-1", "INSIGHTS-MAIN-1"):
+        assert _default_label(sid) in valid, f"{sid}: not registered"
+
+
 def test_looks_like_rate_detects_rate_kpis():
     r = _FakeResult(kpis={"DCTR Rate": "30%"})
     assert _looks_like_rate(r) is True


### PR DESCRIPTION
## Summary

Stacks on W1 #161. Drives the `framework_compliant=False` count in `rates_audit.csv` toward zero before any operator sees the deck.

* Fixes the original W1 prefix-lookup bug (`A1` matched `A11.1` first); now sorts prefixes by descending length
* Expands `DEFAULT_BY_PREFIX` to cover every slide_id ARS modules emit + every W3/TXN spec ID (DCTR-MAIN-*, ATTRITION-MAIN-*, VALUE-MAIN-*, TXN-*, etc.)
* Stamps `denominator_label` + `denominator_n` on the 4 highest-frequency rate-bearing slides: DCTR-1, DCTR-2 (Open whitelist), DCTR-3, A8.1, A9.1, A11.1

## Test plan

- [x] `pytest tests/` — 70/70 passing (4 new in `test_audit.py`)
- [ ] On work PC after W1 + this stack lands: run one ARS client; confirm `rates_audit.csv` shows `framework_compliant=True` for every DCTR-*, A8.*, A9.*, A11.* slide.

## Dependencies

Stacks on W1 #161 — the `denominator_label` field comes from that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)