### PR TITLE
feat(w3): per-month mailer template via pattern-keyed spec resolution

### DIFF
--- a/01_Analysis/00-Scripts/output/slide_spec.py
+++ b/01_Analysis/00-Scripts/output/slide_spec.py
@@ -171,10 +171,86 @@ _SPEC_CACHE: dict[str, dict[str, SlideSpec]] = {}
 
 
 def get_spec(section: str, slide_id: str) -> SlideSpec | None:
-    """Look up a single spec, loading and caching the section file as needed."""
+    """Look up a single spec, loading and caching the section file as needed.
+
+    Two-step resolution:
+      1. Exact match on `slide_id` (the common case).
+      2. Pattern match against keys containing `{name}` placeholders. The first
+         placeholder-keyed spec whose regex matches `slide_id` is returned with
+         the captured value injected as an additional input (`name` -> match).
+         Lets mailer.yml declare ONE template entry like `A13.{month}` that
+         renders every per-month slide (A13.Jan26, A13.Feb26, ...).
+    """
     if section not in _SPEC_CACHE:
         _SPEC_CACHE[section] = load_specs(section)
-    return _SPEC_CACHE[section].get(slide_id)
+    cached = _SPEC_CACHE[section]
+    if slide_id in cached:
+        return cached[slide_id]
+
+    # Pattern match: keys with {name} become regex (?P<name>[^.]+) etc.
+    import re
+    for key, template in cached.items():
+        if "{" not in key:
+            continue
+        pattern_re, capture_names = _compile_pattern_key(key)
+        m = pattern_re.match(slide_id)
+        if m is None:
+            continue
+        # Clone the template and:
+        # 1. Inject captured names as quoted-literal inputs (so the renderer
+        #    treats them as strings, not as dotted paths).
+        # 2. Substitute {name} -> captured value in every input expression so
+        #    `ctx.results.monthly_summaries.{month}.total_mailed` resolves at
+        #    spec-render time.
+        captured = m.groupdict()
+        merged_inputs: dict[str, str] = {}
+        for name, captured_val in captured.items():
+            merged_inputs[name] = f'"{captured_val}"'
+        for input_name, expr in template.inputs.items():
+            substituted = str(expr)
+            for cap_name, cap_val in captured.items():
+                substituted = substituted.replace("{" + cap_name + "}", cap_val)
+            merged_inputs[input_name] = substituted
+        return SlideSpec(
+            slide_id=slide_id,
+            layout=template.layout,
+            components=list(template.components),
+            action_title=template.action_title,
+            inputs=merged_inputs,
+            denominator_label=template.denominator_label,
+            callout=template.callout,
+            footer=template.footer,
+        )
+    return None
+
+
+def _compile_pattern_key(key: str) -> tuple["re.Pattern[str]", list[str]]:
+    """Convert 'A13.{month}' to a compiled regex with named groups.
+
+    Each `{name}` becomes `(?P<name>[^.]+)` so dots in the slide_id still act
+    as path separators. Other characters are escaped.
+    """
+    import re
+    pattern_chars: list[str] = []
+    names: list[str] = []
+    i = 0
+    while i < len(key):
+        ch = key[i]
+        if ch == "{":
+            end = key.find("}", i)
+            if end == -1:
+                pattern_chars.append(re.escape(ch))
+                i += 1
+                continue
+            name = key[i + 1:end]
+            names.append(name)
+            pattern_chars.append(f"(?P<{name}>[^.]+)")
+            i = end + 1
+        else:
+            pattern_chars.append(re.escape(ch))
+            i += 1
+    pattern = "^" + "".join(pattern_chars) + "$"
+    return re.compile(pattern), names
 
 
 def clear_spec_cache() -> None:

--- a/01_Analysis/00-Scripts/tests/test_slide_spec.py
+++ b/01_Analysis/00-Scripts/tests/test_slide_spec.py
@@ -128,6 +128,89 @@ DEMO:
     assert rendered.denominator_label == "Eligible Personal"
 
 
+def test_pattern_key_compiles_to_regex(specs_dir):
+    """`A13.{month}` should match A13.Jan26 and capture 'Jan26'."""
+    pattern, names = ss._compile_pattern_key("A13.{month}")
+    assert names == ["month"]
+    m = pattern.match("A13.Jan26")
+    assert m is not None
+    assert m.group("month") == "Jan26"
+    # Doesn't bleed across dots
+    assert pattern.match("A13.Jan26.Swipes") is None
+    assert pattern.match("A14.Jan26") is None
+
+
+def test_get_spec_resolves_pattern_keyed_template(specs_dir):
+    """Pattern-keyed templates render one spec per matching slide_id."""
+    (specs_dir / "demo.yml").write_text(
+        '''
+"A13.{month}":
+  layout: TWO_CONTENT
+  action_title: "{month_label}: {total_mailed:,} mailed"
+  inputs:
+    month_label: month
+    total_mailed: ctx.results.monthly_summaries.{month}.total_mailed
+  denominator_label: Eligible
+'''
+    )
+    spec = ss.get_spec("demo", "A13.Jan26")
+    assert spec is not None
+    assert spec.slide_id == "A13.Jan26"
+    assert (
+        spec.inputs["total_mailed"]
+        == "ctx.results.monthly_summaries.Jan26.total_mailed"
+    )
+    assert spec.inputs["month"] == '"Jan26"'
+
+
+def test_get_spec_pattern_renders_with_ctx_results(specs_dir):
+    (specs_dir / "demo.yml").write_text(
+        '''
+"A13.{month}":
+  action_title: "{month}: {total_mailed:,} mailed at {overall_rate:.1f}%"
+  inputs:
+    month_label: month
+    total_mailed: ctx.results.monthly_summaries.{month}.total_mailed
+    overall_rate: ctx.results.monthly_summaries.{month}.overall_rate
+  denominator_label: Eligible
+  callout:
+    hero: "{overall_rate:.1f}%"
+'''
+    )
+    spec = ss.get_spec("demo", "A13.Feb26")
+    rendered = ss.render_spec(
+        spec,
+        {
+            "monthly_summaries": {
+                "Feb26": {"total_mailed": 12345, "overall_rate": 4.2},
+                "Jan26": {"total_mailed": 999,   "overall_rate": 9.9},
+            }
+        },
+        _Client(),
+    )
+    assert rendered.action_title == "Feb26: 12,345 mailed at 4.2%"
+    assert rendered.callout_hero == "4.2%"
+    assert "999" not in rendered.action_title
+
+
+def test_get_spec_exact_match_wins_over_pattern(specs_dir):
+    """An exact-match key should be preferred over a pattern-match template."""
+    (specs_dir / "demo.yml").write_text(
+        '''
+"A13.{month}":
+  action_title: "template title"
+  denominator_label: Eligible
+A13.Jan26:
+  action_title: "exact title"
+  denominator_label: Eligible
+'''
+    )
+    spec = ss.get_spec("demo", "A13.Jan26")
+    assert spec.action_title == "exact title"
+    spec2 = ss.get_spec("demo", "A13.Feb26")
+    assert spec2.action_title == "template title"
+
+
 def test_repo_specs_load_without_error():
     """Every authored spec across all sections must parse and be 4-layer compliant."""
     ss.clear_spec_cache()

--- a/docs/slide_specs/mailer.yml
+++ b/docs/slide_specs/mailer.yml
@@ -5,11 +5,12 @@
 # campaign-targeting filter on the numerator framing, not a denominator narrowing.
 #
 # Per-month dynamic specs: mailer has one slide per month
-# (A13.Jan26, A13.Feb26, A13.Mar26, ...). Authoring a row per month here would
-# rot quickly. Instead the aggregate slide is authored (renders every run),
-# plus a generator-prefix MAILER-MONTH-* that deck_builder.py resolves by
-# walking mailer monthly results. The prefix is documented for future use;
-# generator wiring is W3 final follow-up.
+# (A13.Jan26, A13.Feb26, A13.Mar26, ...). Instead of authoring a row per
+# month, the bottom of this file declares ONE template entry keyed by
+# `A13.{month}`. slide_spec.get_spec sees the `{month}` placeholder, treats
+# the entry as a regex template, and renders one resolved SlideSpec per
+# matching slide_id at lookup time. The captured `{month}` is injected as
+# an additional input so action_title / callout can reference it directly.
 
 MAILER-MAIN-AGG:
   layout: TWO_CONTENT
@@ -45,3 +46,25 @@ MAILER-MAIN-REACH:
     tertiary: "{mailed_resp:,} mailer-responders + {mailed_non_resp:,} mailer-non-responders"
   footer:
     source: "Source: {client_name} ODD, {month} | All debit holders within Eligible base"
+
+# Per-month template. Matches every A13.Jan26, A13.Feb26, ... slide_id at
+# lookup time. {month} is captured from the slide_id and exposed as a string
+# input so the action_title and footer can reference it. Each monthly bucket
+# in ctx.results.monthly_summaries is keyed by the same month token.
+"A13.{month}":
+  layout: TWO_CONTENT
+  components: [A13.month]
+  action_title: "{month_label} mailer: {total_mailed:,} mailed, {overall_rate:.1f}% response"
+  inputs:
+    # {month} is injected by get_spec from the slide_id capture (e.g. "Jan26").
+    month_label: month        # plain pass-through; future: format prettier
+    total_mailed: ctx.results.monthly_summaries.{month}.total_mailed
+    total_resp:   ctx.results.monthly_summaries.{month}.total_resp
+    overall_rate: ctx.results.monthly_summaries.{month}.overall_rate
+  denominator_label: Eligible
+  callout:
+    hero: "{overall_rate:.1f}%"
+    sub: "{month} response rate"
+    tertiary: "{total_resp:,} respondents across {total_mailed:,} mailed"
+  footer:
+    source: "Source: {client_name} ODD, {month_label} | Eligible Mailable subset"


### PR DESCRIPTION
## Summary

Stacks on #163. Adds pattern-keyed spec lookup so one template entry in `mailer.yml` renders the correct `SlideSpec` for every per-month mailer slide (`A13.Jan26`, `A13.Feb26`, ...). Closes the last named W3 follow-up.

* `output/slide_spec.py` — `get_spec` does two-step resolution: exact match, then pattern match against keys with `{name}` placeholders. Captured values inject as quoted-literal inputs AND substitute into every input expression so dotted paths like `ctx.results.monthly_summaries.{month}.total_mailed` resolve correctly.
* `docs/slide_specs/mailer.yml` — new `"A13.{month}"` template
* 4 new tests covering compile-to-regex semantics, end-to-end render with substituted dotted paths, exact-match-wins precedence

## Test plan

- [x] `pytest tests/` — 68/68 passing (12 spec tests)
- [ ] On work PC after merge: run a client with monthly mailer data. Confirm each `A13.{month}` slide shows an action title with the month label and that month's response rate, NOT a generic title.

## Stack

Stacks on `feat/w3-slide-design-system` (#163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)