### PR TITLE
config(competition): 1585 First Community Bank of the Heartland

### DIFF
--- a/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
+++ b/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
@@ -684,6 +684,44 @@ CLIENT_CONFIGS = {
         },
     },
 
+    '1585': {  # First Community Bank of the Heartland (Western KY / Northwest TN)
+        'fed_district': '8',
+        'credit_unions': [
+            'LEADERS CREDIT UNION', 'LEADERS CU',
+            'PEOPLES CHOICE CREDIT UNION', "PEOPLE'S CHOICE CREDIT UNION",
+            'PADUCAH FEDERAL CREDIT UNION', 'PADUCAH FEDERAL CU',
+            'CAPE REGIONAL CREDIT UNION', 'CAPE REGIONAL CU',
+            'SIKESTON COMMUNITY CREDIT UNION',
+            'SIKESTON PUBLIC SCHOOL CREDIT UNION',
+            'NAVY FEDERAL CREDIT UNION', 'NAVY FEDERAL CU',
+        ],
+        'local_banks': [
+            'FOCUS BANK',
+            'FOUNDATION BANK',
+            'REELFOOT BANK',
+            'FIRST STATE BANK',
+            'CFSB', 'COMMUNITY FINANCIAL SERVICES BANK',
+            'CITIZENS BANK',
+            'CITIZENS BANK OF FULTON',
+            'CLINTON BANK',
+            'REGIONS BANK',
+            'TRUIST',
+            'RIVER VALLEY AGCREDIT',
+        ],
+        'custom': [],
+        'rollups': {
+            # --- Credit Unions ---
+            'LEADERS CU':                          'LEADERS CREDIT UNION',
+            "PEOPLE'S CHOICE CREDIT UNION":        'PEOPLES CHOICE CREDIT UNION',
+            'PADUCAH FEDERAL CU':                  'PADUCAH FEDERAL CREDIT UNION',
+            'CAPE REGIONAL CU':                    'CAPE REGIONAL CREDIT UNION',
+            'NAVY FEDERAL CU':                     'NAVY FEDERAL CREDIT UNION',
+            # --- Local Banks ---
+            'COMMUNITY FINANCIAL SERVICES BANK':   'CFSB',
+            'CITIZENS BANK OF FULTON':             'CITIZENS BANK',
+        },
+    },
+
     # Template for new clients -- copy and fill in:
     # 'XXXX': {  # Client Name (Location)
     #     'fed_district': '?',


### PR DESCRIPTION
## Summary

Adds the 1585 competitor config (First Community Bank of the Heartland) so the competition section finds CFSB, Leaders CU, Focus Bank, Paducah Federal, etc. instead of falling through to the empty-config branch.

## Background

Salvaged from the dormant PR #139. That PR bundled this config with a TXN-deck-filename-collision fix; the collision fix has since shipped on `main` via a different `deck_builder.py` path (commit notes both fixes happened independently). This PR carries only the config addition — a clean +38-line additive change to `CLIENT_CONFIGS`.

## Verification

- No code change, just a dict entry. Existing config dict syntax preserved.
- Backend tests still pass (136/136).

## Closes

- #138

## After merge

- Close #139 (its collision fix is already on main; only this config remained valuable).

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2xQPyGNY7KtPYM5e9H143)_