### PR TITLE
Concurrent ARS + TXN runs: product-suffixed artifacts + newest-match readers

### DIFF
--- a/01_Analysis/00-Scripts/pipeline/manifest.py
+++ b/01_Analysis/00-Scripts/pipeline/manifest.py
@@ -142,7 +142,10 @@ class RunManifest:
 
     @property
     def path(self) -> Path:
-        return self.output_dir / "run_manifest.json"
+        # TXN runs suffix their artifacts so ARS + TXN can run concurrently
+        # in the same client folder without clobbering each other.
+        suffix = "_txn" if str(self.product).lower() == "txn" else ""
+        return self.output_dir / f"run_manifest{suffix}.json"
 
     def start_run(self) -> None:
         self.started_at = _utcnow_iso()

--- a/01_Analysis/00-Scripts/pipeline/steps/audit.py
+++ b/01_Analysis/00-Scripts/pipeline/steps/audit.py
@@ -154,7 +154,11 @@ def write_rates_audit(ctx: PipelineContext) -> tuple[Path | None, int]:
     if out_dir is None:
         return None, 0
 
-    path = out_dir / "rates_audit.csv"
+    _product = (getattr(ctx, "product", None)
+                or (getattr(ctx.settings, "product", "") if getattr(ctx, "settings", None) else "")
+                or "")
+    _suffix = "_txn" if str(_product).lower() == "txn" else ""
+    path = out_dir / f"rates_audit{_suffix}.csv"
     rows: list[dict[str, object]] = []
     violations = 0
 

--- a/01_Analysis/00-Scripts/pipeline/steps/generate.py
+++ b/01_Analysis/00-Scripts/pipeline/steps/generate.py
@@ -35,6 +35,15 @@ class SlideStatus:
     slide_type: str = "screenshot"
 
 
+def _txn_suffix(ctx: PipelineContext) -> str:
+    """'_txn' for TXN runs, '' otherwise -- keeps ARS artifact names legacy
+    while letting ARS + TXN run concurrently in one client folder."""
+    product = (getattr(ctx, "product", None)
+               or (getattr(ctx.settings, "product", "") if ctx.settings else "")
+               or "")
+    return "_txn" if str(product).lower() == "txn" else ""
+
+
 def _build_run_report(ctx: PipelineContext) -> list[SlideStatus]:
     """Build a diagnostic report of all slide statuses after analysis."""
     report: list[SlideStatus] = []
@@ -76,7 +85,20 @@ def rebuild_deck_from_report(ctx: PipelineContext) -> None:
 
     Returns silently; deck path is added to ctx.export_log on success.
     """
-    report_path = ctx.paths.base_dir / f"{ctx.client.client_id}_{ctx.client.month}_run_report.json"
+    report_path = ctx.paths.base_dir / (
+        f"{ctx.client.client_id}_{ctx.client.month}{_txn_suffix(ctx)}_run_report.json"
+    )
+    if not report_path.exists():
+        # Fall back to the most recent report of either product
+        _cands = sorted(
+            ctx.paths.base_dir.glob(
+                f"{ctx.client.client_id}_{ctx.client.month}*_run_report.json"
+            ),
+            key=lambda f: f.stat().st_mtime,
+            reverse=True,
+        )
+        if _cands:
+            report_path = _cands[0]
     if not report_path.exists():
         logger.warning("rebuild_deck_from_report: {p} not found", p=report_path)
         return
@@ -114,7 +136,9 @@ def rebuild_deck_from_report(ctx: PipelineContext) -> None:
 
 def _save_run_report(ctx: PipelineContext, report: list[SlideStatus]) -> None:
     """Save run report as JSON next to output files."""
-    report_path = ctx.paths.base_dir / f"{ctx.client.client_id}_{ctx.client.month}_run_report.json"
+    report_path = ctx.paths.base_dir / (
+        f"{ctx.client.client_id}_{ctx.client.month}{_txn_suffix(ctx)}_run_report.json"
+    )
     ctx.paths.base_dir.mkdir(parents=True, exist_ok=True)
 
     ok = sum(1 for s in report if s.success and s.has_chart)
@@ -215,7 +239,7 @@ def step_generate(ctx: PipelineContext) -> None:
     if _mf is not None:
         try:
             from ars_analysis.pipeline.scorecard import write as _scorecard_write
-            _scorecard_path = ctx.paths.base_dir / "run_scorecard.md"
+            _scorecard_path = ctx.paths.base_dir / f"run_scorecard{_txn_suffix(ctx)}.md"
             _scorecard_write(_mf, _scorecard_path)
             logger.info("Run scorecard written: {p}", p=_scorecard_path)
         except Exception as _exc:
@@ -233,7 +257,9 @@ def _write_excel(ctx: PipelineContext) -> None:
     Single-write pattern: one workbook with a tab per analysis.
     Then shutil.copy2 for the master/archive copy.
     """
-    excel_path = ctx.paths.excel_dir / f"{ctx.client.client_id}_{ctx.client.month}_analysis.xlsx"
+    excel_path = ctx.paths.excel_dir / (
+        f"{ctx.client.client_id}_{ctx.client.month}{_txn_suffix(ctx)}_analysis.xlsx"
+    )
     ctx.paths.excel_dir.mkdir(parents=True, exist_ok=True)
 
     wb = openpyxl.Workbook()

--- a/02_Presentations/html_review/from_run_report.py
+++ b/02_Presentations/html_review/from_run_report.py
@@ -94,9 +94,14 @@ def build_html_from_run_report(
     can email the HTML or scp it without dragging the assets folder along.
     """
     analysis_dir = completed_analysis_root / csm / month / client_id
-    report_path = analysis_dir / f"{client_id}_{month}_run_report.json"
-    if not report_path.exists():
+    _cands = sorted(
+        analysis_dir.glob(f"{client_id}_{month}*_run_report.json"),
+        key=lambda f: f.stat().st_mtime,
+        reverse=True,
+    )
+    if not _cands:
         return None
+    report_path = _cands[0]
 
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     raw_slides = payload.get("slides") or []

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -85,11 +85,20 @@ def get_code_version() -> dict:
         return {"sha": "", "branch": "", "dirty": False, "label": "unknown"}
 
 
+def _newest_artifact(directory, pattern: str):
+    """Newest file matching pattern (TXN runs suffix their artifacts so ARS +
+    TXN can run concurrently; readers show whichever finished last)."""
+    candidates = sorted(
+        directory.glob(pattern), key=lambda f: f.stat().st_mtime, reverse=True
+    )
+    return candidates[0] if candidates else None
+
+
 def load_run_report(csm: str, month: str, client_id: str) -> dict | None:
     """Load the persisted run_report.json for a completed run, or None."""
     analysis_dir = _resolve_csm_dir(COMPLETED_ANALYSIS, csm) / month / client_id
-    report_path = analysis_dir / f"{client_id}_{month}_run_report.json"
-    if not report_path.exists():
+    report_path = _newest_artifact(analysis_dir, f"{client_id}_{month}*_run_report.json")
+    if report_path is None:
         return None
     try:
         return json.loads(report_path.read_text(encoding="utf-8"))
@@ -948,16 +957,16 @@ async def run_quality(csm: str, month: str, client_id: str):
     if not analysis_dir.exists():
         return out
 
-    sc = analysis_dir / "run_scorecard.md"
-    if sc.exists():
+    sc = _newest_artifact(analysis_dir, "run_scorecard*.md")
+    if sc:
         out["scorecard_path"] = str(sc)
         try:
             out["scorecard_md"] = sc.read_text(encoding="utf-8")
         except Exception:
             pass
 
-    ra = analysis_dir / "rates_audit.csv"
-    if ra.exists():
+    ra = _newest_artifact(analysis_dir, "rates_audit*.csv")
+    if ra:
         out["rates_audit_path"] = str(ra)
         try:
             with open(ra, newline="", encoding="utf-8") as f:
@@ -969,8 +978,8 @@ async def run_quality(csm: str, month: str, client_id: str):
         except Exception:
             pass
 
-    mf = analysis_dir / "run_manifest.json"
-    if mf.exists():
+    mf = _newest_artifact(analysis_dir, "run_manifest*.json")
+    if mf:
         try:
             data = _json.loads(mf.read_text(encoding="utf-8"))
             out["manifest_status"] = data.get("status", "unknown")


### PR DESCRIPTION
## Summary

Unblocks running the ARS and TXN analyses **simultaneously** for the same client/month. The UI already launches runs as independent subprocesses; the blocker was five artifacts with fixed filenames in the shared client folder — parallel runs would interleave writes and the last finisher wins.

**TXN runs now suffix their artifacts** (ARS keeps legacy names, so nothing existing breaks):
- `run_manifest_txn.json`, `run_scorecard_txn.md`, `rates_audit_txn.csv`
- `{client}_{month}_txn_run_report.json`, `{client}_{month}_txn_analysis.xlsx`

**Readers resolve newest-match with legacy fallback**: UI run-quality panel, Curate panel / manifest sync, deck rebuild, and HTML preview.

Deck filenames were already product-separated (PR #139) and ARS/TXN chart PNGs don't share names, so those were already safe.

## Verification
- 155 backend + 12 UI + 19 html_review tests pass; ruff clean.
- Legacy-named fixtures still resolve through every patched reader (newest-match falls back).

## Usage
Pull, restart the UI, then start the TXN run and the ARS run from two tabs. Heads-up: they'll compete for CPU/RAM on one box, so the TXN wall-clock may stretch somewhat — but total elapsed ≈ the TXN run alone.

https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka)_