### PR TITLE
UI: product-card counts from files on disk, not hardcoded copy

### DIFF
--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -483,6 +483,41 @@ async def get_products():
     return PRODUCTS
 
 
+@app.get("/api/module_counts")
+async def module_counts():
+    """Live module/section/script counts from the files actually on disk.
+
+    The product cards previously showed hardcoded copy ('22 modules') that
+    silently went stale as analytics cells were added or deleted -- which
+    made real pipeline changes look like they hadn't landed."""
+    analytics = Path(__file__).resolve().parent.parent / "01_Analysis" / "00-Scripts" / "analytics"
+    # Section dirs are stable; cells inside them are what churns.
+    txn_sections = [
+        "general", "merchant", "mcc_code", "business_accts", "personal_accts",
+        "competition", "financial_services", "ics_acquisition", "campaign",
+        "branch_txn", "transaction_type", "product", "attrition_txn", "balance",
+        "interchange", "rege_overdraft", "payroll", "relationship",
+        "segment_evolution", "retention", "engagement", "executive",
+    ]
+    ars_dirs = ["overview", "dctr", "rege", "attrition", "value", "mailer", "insights", "ics"]
+
+    def _modules(d: str) -> int:
+        p = analytics / d
+        if not p.is_dir():
+            return 0
+        return len([f for f in p.glob("*.py") if not f.name.startswith("_")])
+
+    ars = sum(_modules(d) for d in ars_dirs)
+    txn_existing = [d for d in txn_sections if (analytics / d).is_dir()]
+    txn_scripts = sum(_modules(d) for d in txn_existing)
+    return {
+        "ars_modules": ars,
+        "txn_sections": len(txn_existing),
+        "txn_scripts": txn_scripts,
+        "combined": ars + len(txn_existing),
+    }
+
+
 @app.get("/api/months")
 async def get_months(csm: str = "", source: str = "all"):
     """Return available months by scanning actual directories.

--- a/05_UI/index.html
+++ b/05_UI/index.html
@@ -2435,6 +2435,28 @@ async function loadResultsClients() {
 // Load dashboard data on page load
 loadDashboardData();
 
+// Product-card counts come from the files on disk, not hardcoded copy --
+// so deleting/adding analytics cells is visible here immediately.
+(async () => {
+    try {
+        const r = await fetch('/api/module_counts');
+        if (!r.ok) return;
+        const c = await r.json();
+        document.querySelectorAll('.p-card').forEach(card => {
+            const k = (card.getAttribute('onclick') || '').match(/selectProd\('(\w+)'\)/)?.[1];
+            const el = card.querySelector('.p-count');
+            if (!el) return;
+            if (k === 'ars' && c.ars_modules) el.textContent = c.ars_modules;
+            if (k === 'txn' && c.txn_sections) {
+                el.textContent = c.txn_sections;
+                const t = card.querySelector('.p-time');
+                if (t && c.txn_scripts) t.textContent = `${c.txn_scripts} cells · ~ 20-35 min`;
+            }
+            if (k === 'combined' && c.combined) el.textContent = c.combined;
+        });
+    } catch (e) {}
+})();
+
 // Footer code-version chip: surfaces what checkout the server is running so
 // a stale work-PC clone is caught before a client run, not after.
 (async () => {


### PR DESCRIPTION
## Summary

The Generate tab's product cards showed **hardcoded counts** ("22 modules", "22 sections") written when the cards were built and never wired to the pipeline — so real changes (deleted cells, new modules) were landing fine but looked like they weren't. ARS actually has **26** modules; the card has said 22 for months.

New `GET /api/module_counts` scans the analytics directories on disk (pure filesystem, no imports) and the cards self-update on load:
- **ARS**: live module-file count (26 today)
- **TXN**: live section count (22 — correct; we deleted *cells*, not sections) plus a live **cell count** ("323 cells") that visibly drops with every deletion
- **Combined**: derived sum

## Verification
- UI suite passes (12/12); endpoint returns `{'ars_modules': 26, 'txn_sections': 22, 'txn_scripts': 323, 'combined': 48}` against this tree.

https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka)_