### PR TITLE
Mailer combo lines: restart-free kill switch + per-wave timing

### DIFF
--- a/01_Analysis/00-Scripts/analytics/mailer/cohort.py
+++ b/01_Analysis/00-Scripts/analytics/mailer/cohort.py
@@ -403,6 +403,17 @@ def build_combo_lines(
     spend_cols: list[str],
     swipe_cols: list[str],
 ) -> list[AnalysisResult]:
+    import os as _os
+    import time as _time
+    from pathlib import Path as _Path
+
+    # Kill switch that needs NO restart: set env ARS_SKIP_COMBO=1, or drop a
+    # file named SKIP_COMBO.flag at the ARS root (M:\ARS). Escape hatch for
+    # mid-deadline recovery after this cell hung a production run.
+    _flag = _Path(__file__).resolve().parents[4] / "SKIP_COMBO.flag"
+    if _os.environ.get("ARS_SKIP_COMBO") == "1" or _flag.exists():
+        logger.warning("A16.7 combo lines SKIPPED (kill switch active)")
+        return []
     """Per-wave combo chart: 2 rows (Spend top, Swipes bottom) x N segment panels.
 
     Each panel shows Responder vs Non-Responder avg monthly value, with a
@@ -449,6 +460,8 @@ def build_combo_lines(
     )[:2]
 
     for month, resp_col, mail_col in dated_pairs:
+        _wave_t0 = _time.monotonic()
+        logger.info("A16.7 {month}: starting combo render", month=month)
         mail_date = parse_month(month)
 
         # Classify accounts for this wave
@@ -664,6 +677,10 @@ def build_combo_lines(
         fig.savefig(save_to, dpi=150, bbox_inches="tight")
         plt.close(fig)
 
+        logger.info(
+            "A16.7 {month}: {n} panels rendered in {secs:.1f}s",
+            month=month, n=len(all_segs), secs=_time.monotonic() - _wave_t0,
+        )
         results.append(
             AnalysisResult(
                 slide_id=f"A16.7.{month}",


### PR DESCRIPTION
Follow-up to #197 (the 67-minute combo-lines hang) — two mid-deadline recovery tools:

- **Kill switch that needs no restart** (the UI server must stay up during a concurrent TXN run): set env `ARS_SKIP_COMBO=1` **or drop a file named `SKIP_COMBO.flag` at the ARS repo root** (`M:\ARS\SKIP_COMBO.flag`). A16.7 combo slides are skipped with a logged warning; the rest of the mailer section proceeds normally.
- **Per-wave timing in the live log** (`A16.7 Jan26: starting combo render` → `… 5 panels rendered in 3.2s`) so a slow render identifies itself instead of looking like a silent stall.

155 tests pass.

https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka)_