### PR TITLE
Owner corrections: Reg E funnel rate basis + attrition full-book default

### DIFF
--- a/01_Analysis/00-Scripts/analytics/attrition/_helpers.py
+++ b/01_Analysis/00-Scripts/analytics/attrition/_helpers.py
@@ -252,7 +252,16 @@ def prepare_attrition_data(
         empty = pd.DataFrame()
         return empty, empty, empty
 
-    data = attrition_universe(ctx)
+    # Full book by default. The eligible-products scoping (attrition_universe)
+    # collapsed closure counts to implausible levels on real data (owner
+    # report: ~100 L12M closures) -- the configured eligible products cover
+    # only part of the closing book. Opt in explicitly when wanted:
+    #   ARS_ATTRITION_ELIGIBLE_ONLY=1
+    import os as _os
+    if _os.environ.get("ARS_ATTRITION_ELIGIBLE_ONLY") == "1":
+        data = attrition_universe(ctx)
+    else:
+        data = ctx.data
 
     open_accts = data[data["Date Closed"].isna()].copy()
     closed_accts = data[data["Date Closed"].notna()].copy()

--- a/01_Analysis/00-Scripts/analytics/rege/dimensions.py
+++ b/01_Analysis/00-Scripts/analytics/rege/dimensions.py
@@ -60,6 +60,9 @@ def _render_funnel(
         [s["name"] for s in stages],
         [float(s["total"]) for s in stages],
         label_fontsize=15,
+        pct_of="prev",  # owner formula: each stage as conversion of the prior
+                        # stage, so the final bar IS the Reg E opt-in rate
+                        # (personal w/ Reg E / eligible personal w/debit)
     )
     ax.set_title(title_text, fontsize=20, fontweight="bold", pad=34)
     ax.text(

--- a/01_Analysis/00-Scripts/shared/charts.py
+++ b/01_Analysis/00-Scripts/shared/charts.py
@@ -40,6 +40,7 @@ def draw_funnel(
     value_fmt: str = "{:,.0f}",
     highlight_biggest_drop: bool = True,
     label_fontsize: int = 14,
+    pct_of: str = "first",
 ) -> None:
     """Draw a horizontal funnel: centered bars + drop-off connectors.
 
@@ -74,7 +75,13 @@ def draw_funnel(
     for i, (stage, v) in enumerate(zip(stages, values)):
         color = final_color if i == n - 1 else bar_color
         ax.barh(i, v, left=(vmax - v) / 2, height=0.62, color=color, zorder=3)
-        label = f"{value_fmt.format(v)}  ({v / values[0]:.0%})"
+        # pct_of="first": share of the top stage. pct_of="prev": conversion
+        # from the preceding stage -- so a rate DEFINED as stageN/stageN-1
+        # (e.g. Reg E opt-in = personal w/ Reg E / eligible personal w/debit)
+        # appears on the bar itself, not just in a side box.
+        pct_base = values[0] if (pct_of == "first" or i == 0) else values[i - 1]
+        pct = (v / pct_base) if pct_base else 0.0
+        label = f"{value_fmt.format(v)}  ({pct:.1%})" if pct_of == "prev" else             f"{value_fmt.format(v)}  ({pct:.0%})"
         if v > vmax * 0.22:
             ax.text(vmax / 2, i, label, ha="center", va="center",
                     fontsize=label_fontsize, fontweight="bold", color="white", zorder=4)

--- a/01_Analysis/00-Scripts/tests/test_attrition_calcs.py
+++ b/01_Analysis/00-Scripts/tests/test_attrition_calcs.py
@@ -136,9 +136,10 @@ def test_personal_business_normalizes_flag_values(tmp_path):
 
 
 def test_attrition_universe_scopes_to_eligible_products(tmp_path):
-    """Owner rule: attrition uses the proper open/eligible subsets.
-    Open rows = exactly ctx.subsets.eligible_data; closed rows = eligible
-    PRODUCT codes only (closure rewrites the stat code)."""
+    """Eligible-products scoping is OPT-IN (ARS_ATTRITION_ELIGIBLE_ONLY=1).
+    Default is the full book -- forced scoping collapsed real closure counts.
+    When opted in: open rows = ctx.subsets.eligible_data; closed rows =
+    eligible PRODUCT codes only (closure rewrites the stat code)."""
     df = pd.DataFrame({
         "Date Opened": ["2020-01-01"] * 6,
         "Date Closed": [None, None, None, "2025-12-01", "2025-12-01", "2025-12-01"],
@@ -150,8 +151,13 @@ def test_attrition_universe_scopes_to_eligible_products(tmp_path):
     # eligible_data = open + eligible stat ("2") + eligible product -> row 0 only
     ctx.subsets = SimpleNamespace(eligible_data=ctx.data.iloc[[0]])
 
+    import os
     from ars_analysis.analytics.attrition._helpers import prepare_attrition_data
-    universe, open_u, closed_u = prepare_attrition_data(ctx)
+    os.environ["ARS_ATTRITION_ELIGIBLE_ONLY"] = "1"
+    try:
+        universe, open_u, closed_u = prepare_attrition_data(ctx)
+    finally:
+        del os.environ["ARS_ATTRITION_ELIGIBLE_ONLY"]
 
     # Open: only the eligible_data row (row 1 wrong product, row 2 wrong stat)
     assert list(open_u.index) == [0]


### PR DESCRIPTION
Two owner-reported regressions from tonight's first production run:

1. **Reg E funnel showed the wrong denominator on every bar** — percentages were share-of-stage-1 (open accounts), burying the defined opt-in rate (personal w/ Reg E ÷ eligible personal w/debit) in a corner box. `draw_funnel` gains `pct_of="prev"` (conversion from the preceding stage); the Reg E funnels use it, so the final bar **is** the owner's rate. The A3 eligibility funnel keeps share-of-total (its rate is defined against total accounts).

2. **Attrition eligible-products scoping collapsed real closure counts** (~100 L12M closures reported — implausible; the configured eligible products cover only part of the closing book). Attrition defaults back to the **full book**; the standardized L12M window fix stays; scoping becomes opt-in via `ARS_ATTRITION_ELIGIBLE_ONLY=1`. Also removes the tile-vs-chart count mismatch (one population everywhere).

155 tests pass.

https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxTyGhJvaBokWgwg4p7Eka)_