### PR TITLE
fix(05_UI): correct stale product-card counts (TXN 22→35, Combined 47→57)

### DIFF
--- a/05_UI/index.html
+++ b/05_UI/index.html
@@ -680,8 +680,8 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
 
         <div class="grid-4" style="margin-bottom: 0;">
             <div class="p-card on" onclick="selectProd('ars')"><div class="p-name">ARS Full Suite</div><div class="p-count">22</div><div class="p-unit">modules</div><div class="p-time">~ 15-25 min</div></div>
-            <div class="p-card" onclick="selectProd('txn')"><div class="p-name">Transaction</div><div class="p-count">22</div><div class="p-unit">sections</div><div class="p-time">~ 20-35 min</div></div>
-            <div class="p-card" onclick="selectProd('combined')"><div class="p-name">Combined</div><div class="p-count">47</div><div class="p-unit">ARS + TXN</div><div class="p-time">~ 35-55 min</div></div>
+            <div class="p-card" onclick="selectProd('txn')"><div class="p-name">Transaction</div><div class="p-count">35</div><div class="p-unit">sections</div><div class="p-time">~ 20-35 min</div></div>
+            <div class="p-card" onclick="selectProd('combined')"><div class="p-name">Combined</div><div class="p-count">57</div><div class="p-unit">ARS + TXN</div><div class="p-time">~ 35-55 min</div></div>
             <div class="p-card" onclick="selectProd('dep')"><div class="p-name">Deposits</div><div class="p-count">15</div><div class="p-unit">modules</div><div class="p-time">~ 10-20 min</div></div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

The product cards on the Generate screen hardcoded module counts that had drifted from the authoritative `PRODUCTS` registry (`05_UI/app.py:186`) and the expandable detail panel below the cards.

| Card | Was | Now | Source of truth |
|---|---|---|---|
| Transaction | 22 sections | **35** | `PRODUCTS['txn']` sums to 35 (5+8+6+8+5+3) |
| Combined | 47 | **57** | ARS (22) + TXN (35) |

ARS (22) and Deposits (15) were already correct and are untouched.

### Operator-facing effect
The Transaction and Combined cards now show the same count the detail panel and the actual run report — previously clicking Transaction made the count jump from 22 to 35, which read like a glitch.

### Caveats / follow-ups (not in this PR)
- **Combined = 57 is the additive sum.** "combined" has no entry in the `PRODUCTS` registry (the backend just passes `--product combined` to the CLI), so if the combined run dedupes modules shared by ARS and TXN (e.g. Attrition), the true figure could be lower. 57 is the honest upper bound; flag if you want it verified against an actual combined run.
- **Counts live in three places** — these cards, the `prodData` JS object (`index.html:1029`), and the backend `PRODUCTS` dict. Sourcing the cards from the existing `/api/products` endpoint would prevent this drift permanently. Left as a follow-up.
- The Transaction card time (`~ 20-35 min`) still differs from the registry (`25-40 min`) — left as-is since it wasn't in scope; happy to align it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)