### PR TITLE
Competitor configs: 1759 + 5 more clients (Ellafi, PrimeTrust, Pioneer, USF, Fort Sill)

### DIFF
--- a/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
+++ b/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
@@ -520,6 +520,67 @@ CLIENT_CONFIGS = {
             'MOUNT MCKINLEY BANK':                   'MT. MCKINLEY BANK',
         },
     },
+    '1759': {  # First Central Credit Union (Waco, TX)
+        'fed_district': '11',  # Dallas -- TX/LA/NM (was silently defaulting to '12' SF)
+        'credit_unions': [
+            # --- Waco / Central Texas locals ---
+            'GENCO FEDERAL CREDIT UNION', 'GENCO FCU', 'GENCO',          # Waco HQ -- top local CU
+            'MEMBERS CHOICE OF CENTRAL TEXAS',
+            'MEMBERS CHOICE OF CENTRAL TEXAS FEDERAL CREDIT UNION',
+            'TEXELL CREDIT UNION', 'TEXELL CU', 'TEXELL',                # Woodway / Temple
+            'EDUCATORS CREDIT UNION', 'EDUCATORS CU',                    # Waco
+            '1ST UNIVERSITY CREDIT UNION', 'FIRST UNIVERSITY CREDIT UNION', '1ST UNIVERSITY CU',
+            'GREATER CENTRAL TEXAS FEDERAL CREDIT UNION', 'GREATER CENTRAL TEXAS FCU',  # Killeen
+            # --- Large statewide CUs commonly seen in Central TX member data ---
+            'RANDOLPH-BROOKS FEDERAL CREDIT UNION', 'RANDOLPH BROOKS', 'RBFCU',
+            'UNIVERSITY FEDERAL CREDIT UNION', 'UFCU',
+            'TEXAS DOW EMPLOYEES CREDIT UNION', 'TDECU',
+            'SECURITY SERVICE FEDERAL CREDIT UNION', 'SECURITY SERVICE FCU', 'SSFCU',
+            # Heavy military presence nearby (Fort Cavazos / Killeen)
+            'NAVY FEDERAL CREDIT UNION', 'NAVY FEDERAL CU',
+        ],
+        'local_banks': [
+            # Waco-area community banks NOT already in the District 11 top-25
+            'CENTRAL NATIONAL BANK',                                     # Waco's leading independent bank
+            'EXTRACO BANKS', 'EXTRACO BANK', 'EXTRACO',                  # Temple / Waco
+            'TFNB', 'TFNB YOUR BANK FOR LIFE',
+            'FIRST NATIONAL BANK OF MCGREGOR', 'THE FIRST NATIONAL BANK OF MCGREGOR',
+            'ALLIANCE BANK CENTRAL TEXAS',                              # Woodway
+            'COMMUNITY BANK & TRUST', 'COMMUNITY BANK AND TRUST',        # Waco
+            'FIRST NATIONAL BANK OF CENTRAL TEXAS', 'FNBCT',
+            'FIRST NATIONAL BANK TEXAS', 'FIRST CONVENIENCE BANK',       # Killeen HQ; heavy HEB retail footprint
+            'AMERICAN BANK',                                             # Waco -- generic name, watch for out-of-market FPs
+        ],
+        'custom': [],
+        'rollups': {
+            # --- CU abbreviation / variant rollups ---
+            'GENCO FCU':                                            'GENCO FEDERAL CREDIT UNION',
+            'GENCO':                                                'GENCO FEDERAL CREDIT UNION',
+            'MEMBERS CHOICE OF CENTRAL TEXAS FEDERAL CREDIT UNION': 'MEMBERS CHOICE OF CENTRAL TEXAS',
+            'TEXELL CU':                                            'TEXELL CREDIT UNION',
+            'TEXELL':                                               'TEXELL CREDIT UNION',
+            'EDUCATORS CU':                                         'EDUCATORS CREDIT UNION',
+            'FIRST UNIVERSITY CREDIT UNION':                        '1ST UNIVERSITY CREDIT UNION',
+            '1ST UNIVERSITY CU':                                    '1ST UNIVERSITY CREDIT UNION',
+            'GREATER CENTRAL TEXAS FCU':                            'GREATER CENTRAL TEXAS FEDERAL CREDIT UNION',
+            'RANDOLPH BROOKS':                                      'RANDOLPH-BROOKS FEDERAL CREDIT UNION',
+            'RBFCU':                                                'RANDOLPH-BROOKS FEDERAL CREDIT UNION',
+            'UFCU':                                                 'UNIVERSITY FEDERAL CREDIT UNION',
+            'TDECU':                                                'TEXAS DOW EMPLOYEES CREDIT UNION',
+            'SECURITY SERVICE FCU':                                 'SECURITY SERVICE FEDERAL CREDIT UNION',
+            'SSFCU':                                                'SECURITY SERVICE FEDERAL CREDIT UNION',
+            'NAVY FEDERAL CU':                                      'NAVY FEDERAL CREDIT UNION',
+            # --- Local bank variant rollups ---
+            'EXTRACO BANK':                                         'EXTRACO BANKS',
+            'EXTRACO':                                              'EXTRACO BANKS',
+            'TFNB YOUR BANK FOR LIFE':                              'TFNB',
+            'FIRST NATIONAL BANK OF MCGREGOR':                      'TFNB',
+            'THE FIRST NATIONAL BANK OF MCGREGOR':                  'TFNB',
+            'COMMUNITY BANK AND TRUST':                             'COMMUNITY BANK & TRUST',
+            'FNBCT':                                                'FIRST NATIONAL BANK OF CENTRAL TEXAS',
+            'FIRST CONVENIENCE BANK':                               'FIRST NATIONAL BANK TEXAS',
+        },
+    },
     '1776': {  # CoastHills (Central Coast, CA)
         'fed_district': '12',
         'credit_unions': [

--- a/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
+++ b/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
@@ -581,6 +581,178 @@ CLIENT_CONFIGS = {
             'FIRST CONVENIENCE BANK':                               'FIRST NATIONAL BANK TEXAS',
         },
     },
+    '1226': {  # Ellafi Federal Credit Union (formerly Seasons FCU) -- Middletown, CT
+        'fed_district': '1',  # Boston -- central CT (Middlesex County)
+        'credit_unions': [
+            'AMERICAN EAGLE FINANCIAL CREDIT UNION', 'AMERICAN EAGLE CREDIT UNION',
+            'AMERICAN EAGLE FCU', 'AEFCU',                       # CT's largest community CU; serves Middlesex
+            'CONNEX CREDIT UNION', 'CONNEX CU',                  # North Haven; serves Middlesex
+            'NUTMEG STATE FINANCIAL CREDIT UNION', 'NUTMEG STATE CREDIT UNION', 'NUTMEG STATE CU',
+            'DUTCH POINT CREDIT UNION', 'DUTCH POINT CU',        # Wethersfield; absorbed MidConn of Middletown
+            'CHARTER OAK FEDERAL CREDIT UNION', 'CHARTER OAK FCU',
+            'NAVY FEDERAL CREDIT UNION', 'NAVY FEDERAL CU',
+        ],
+        'local_banks': [
+            'LIBERTY BANK',                                      # Middletown HQ -- 3rd largest CT bank
+            'WEBSTER BANK',
+            'ION BANK',
+            'THOMASTON SAVINGS BANK',
+            'CHELSEA GROTON BANK',
+        ],
+        'custom': [],
+        'rollups': {
+            'AMERICAN EAGLE CREDIT UNION':       'AMERICAN EAGLE FINANCIAL CREDIT UNION',
+            'AMERICAN EAGLE FCU':                'AMERICAN EAGLE FINANCIAL CREDIT UNION',
+            'AEFCU':                             'AMERICAN EAGLE FINANCIAL CREDIT UNION',
+            'CONNEX CU':                         'CONNEX CREDIT UNION',
+            'NUTMEG STATE CREDIT UNION':         'NUTMEG STATE FINANCIAL CREDIT UNION',
+            'NUTMEG STATE CU':                   'NUTMEG STATE FINANCIAL CREDIT UNION',
+            'DUTCH POINT CU':                    'DUTCH POINT CREDIT UNION',
+            'CHARTER OAK FCU':                   'CHARTER OAK FEDERAL CREDIT UNION',
+            'NAVY FEDERAL CU':                   'NAVY FEDERAL CREDIT UNION',
+        },
+    },
+    '1746': {  # PrimeTrust Federal Credit Union -- Muncie, IN
+        'fed_district': '7',  # Chicago -- covers Indiana
+        'credit_unions': [
+            'BALL STATE FEDERAL CREDIT UNION', 'BALL STATE FCU',  # Muncie / Ball State
+            'INDIANA MEMBERS CREDIT UNION', 'IMCU',               # Muncie branch
+            'PROFED CREDIT UNION', 'PROFED FEDERAL CREDIT UNION', 'PROFED FCU',
+            'FORUM CREDIT UNION', 'FORUM CU',
+            'CENTRA CREDIT UNION', 'CENTRA CU',
+            'NAVY FEDERAL CREDIT UNION', 'NAVY FEDERAL CU',
+        ],
+        'local_banks': [
+            'FIRST MERCHANTS BANK', 'FIRST MERCHANTS',            # Muncie HQ -- dominant Central IN bank
+            'MUTUALBANK', 'MUTUAL BANK',                          # Muncie HQ legacy (acq. Northwest 2020)
+            'NORTHWEST BANK',
+            'OLD NATIONAL BANK',
+            'STAR FINANCIAL BANK', 'STAR BANK',
+        ],
+        'custom': [],
+        'rollups': {
+            'BALL STATE FCU':            'BALL STATE FEDERAL CREDIT UNION',
+            'IMCU':                      'INDIANA MEMBERS CREDIT UNION',
+            'PROFED FEDERAL CREDIT UNION': 'PROFED CREDIT UNION',
+            'PROFED FCU':                'PROFED CREDIT UNION',
+            'FORUM CU':                  'FORUM CREDIT UNION',
+            'CENTRA CU':                 'CENTRA CREDIT UNION',
+            'NAVY FEDERAL CU':           'NAVY FEDERAL CREDIT UNION',
+            'FIRST MERCHANTS':           'FIRST MERCHANTS BANK',
+            'MUTUAL BANK':               'MUTUALBANK',
+            'STAR BANK':                 'STAR FINANCIAL BANK',
+        },
+    },
+    '1217': {  # Pioneer Federal Credit Union -- Mountain Home, ID
+        'fed_district': '12',  # San Francisco -- covers Idaho
+        'credit_unions': [
+            'IDAHO CENTRAL CREDIT UNION', 'ICCU',                 # dominant ID CU; Mountain Home branch
+            'CAPED CREDIT UNION', 'CAP ED CREDIT UNION', 'CAPED CU',
+            'ICON CREDIT UNION', 'ICON CU',
+            'WESTMARK CREDIT UNION', 'WESTMARK CU',
+            'MOUNTAIN AMERICA CREDIT UNION', 'MOUNTAIN AMERICA CU', 'MACU',
+            'NORTHWEST CHRISTIAN CREDIT UNION',                   # Mountain Home
+            'CLARITY CREDIT UNION',                               # Meridian
+        ],
+        'local_banks': [
+            # Treasure Valley locals NOT already in the District 12 top-25
+            'D.L. EVANS BANK', 'DL EVANS BANK', 'D L EVANS BANK',
+            'BANK OF IDAHO',
+            'IDAHO FIRST BANK',
+            'IDAHO INDEPENDENT BANK',                             # legacy (merged into First Interstate)
+            'FIRST INTERSTATE BANK',
+        ],
+        'custom': [],
+        'rollups': {
+            'ICCU':                      'IDAHO CENTRAL CREDIT UNION',
+            'CAP ED CREDIT UNION':       'CAPED CREDIT UNION',
+            'CAPED CU':                  'CAPED CREDIT UNION',
+            'ICON CU':                   'ICON CREDIT UNION',
+            'WESTMARK CU':               'WESTMARK CREDIT UNION',
+            'MOUNTAIN AMERICA CU':       'MOUNTAIN AMERICA CREDIT UNION',
+            'MACU':                      'MOUNTAIN AMERICA CREDIT UNION',
+            'DL EVANS BANK':             'D.L. EVANS BANK',
+            'D L EVANS BANK':            'D.L. EVANS BANK',
+        },
+    },
+    '1780': {  # USF Federal Credit Union (now USF CU) -- Tampa, FL
+        'fed_district': '6',  # Atlanta -- covers Florida
+        'credit_unions': [
+            'SUNCOAST CREDIT UNION', 'SUNCOAST CU', 'SUNCOAST SCHOOLS FEDERAL CREDIT UNION',  # Tampa HQ; FL's largest
+            'GTE FINANCIAL', 'GTE FEDERAL CREDIT UNION', 'GTE FCU',  # Tampa HQ
+            'GROW FINANCIAL FEDERAL CREDIT UNION', 'GROW FINANCIAL', 'GROW FINANCIAL FCU',  # Tampa HQ
+            'ACHIEVA CREDIT UNION', 'ACHIEVA CU',
+            'MIDFLORIDA CREDIT UNION', 'MIDFLORIDA CU', 'MID FLORIDA CREDIT UNION',
+            'VYSTAR CREDIT UNION', 'VYSTAR CU',
+            'NAVY FEDERAL CREDIT UNION', 'NAVY FEDERAL CU',      # MacDill AFB
+        ],
+        'local_banks': [
+            'THE BANK OF TAMPA', 'BANK OF TAMPA',                # Tampa HQ community bank
+            'AMERANT BANK', 'AMERANT',
+            'SEACOAST BANK', 'SEACOAST NATIONAL BANK',
+            'SOUTHSTATE BANK', 'SOUTH STATE BANK',
+            'RAYMOND JAMES BANK',                               # St. Petersburg
+        ],
+        'custom': ['USAA'],                                     # MacDill AFB military presence
+        'rollups': {
+            'SUNCOAST CU':                          'SUNCOAST CREDIT UNION',
+            'SUNCOAST SCHOOLS FEDERAL CREDIT UNION': 'SUNCOAST CREDIT UNION',
+            'GTE FEDERAL CREDIT UNION':             'GTE FINANCIAL',
+            'GTE FCU':                              'GTE FINANCIAL',
+            'GROW FINANCIAL FCU':                   'GROW FINANCIAL FEDERAL CREDIT UNION',
+            'GROW FINANCIAL':                       'GROW FINANCIAL FEDERAL CREDIT UNION',
+            'ACHIEVA CU':                           'ACHIEVA CREDIT UNION',
+            'MIDFLORIDA CU':                        'MIDFLORIDA CREDIT UNION',
+            'MID FLORIDA CREDIT UNION':             'MIDFLORIDA CREDIT UNION',
+            'VYSTAR CU':                            'VYSTAR CREDIT UNION',
+            'NAVY FEDERAL CU':                      'NAVY FEDERAL CREDIT UNION',
+            'BANK OF TAMPA':                        'THE BANK OF TAMPA',
+            'AMERANT':                              'AMERANT BANK',
+            'SEACOAST NATIONAL BANK':               'SEACOAST BANK',
+            'SOUTH STATE BANK':                     'SOUTHSTATE BANK',
+        },
+    },
+    '1766': {  # Fort Sill Federal Credit Union -- Lawton, OK (Army post)
+        'fed_district': '10',  # Kansas City -- covers Oklahoma
+        'credit_unions': [
+            'COMANCHE COUNTY FEDERAL CREDIT UNION', 'COMANCHE COUNTY FCU',  # Lawton
+            'SOUTHWEST OKLAHOMA FEDERAL CREDIT UNION', 'SOUTHWEST OKLAHOMA FCU',  # Lawton
+            'TINKER FEDERAL CREDIT UNION', 'TINKER FCU', 'TFCU',  # OK's largest CU
+            'COMMUNICATION FEDERAL CREDIT UNION', 'COMMUNICATION FCU',
+            'WEOKIE CREDIT UNION', 'WEOKIE FEDERAL CREDIT UNION', 'WEOKIE',
+            'NAVY FEDERAL CREDIT UNION', 'NAVY FEDERAL CU',
+        ],
+        'local_banks': [
+            # NOTE: FSNB / Fort Sill National Bank is a SEPARATE institution from the
+            # client (Fort Sill FEDERAL CREDIT UNION). Full-string patterns only -- never
+            # a bare 'FORT SILL' that would match the client against itself.
+            'FSNB', 'FORT SILL NATIONAL BANK',                  # Lawton HQ
+            'CITY NATIONAL BANK & TRUST', 'CITY NATIONAL BANK AND TRUST',  # Lawton
+            'LIBERTY NATIONAL BANK',                            # Lawton
+            'FIRST NATIONAL BANK & TRUST', 'FIRST NATIONAL BANK AND TRUST',  # Lawton
+            'ARVEST BANK',
+            'BANCFIRST',
+            'BANK OF OKLAHOMA', 'BOK FINANCIAL', 'BOKF',
+            'IBC BANK', 'INTERNATIONAL BANK OF COMMERCE',
+        ],
+        'custom': ['USAA'],                                     # Fort Sill Army post military presence
+        'rollups': {
+            'COMANCHE COUNTY FCU':       'COMANCHE COUNTY FEDERAL CREDIT UNION',
+            'SOUTHWEST OKLAHOMA FCU':    'SOUTHWEST OKLAHOMA FEDERAL CREDIT UNION',
+            'TINKER FCU':                'TINKER FEDERAL CREDIT UNION',
+            'TFCU':                      'TINKER FEDERAL CREDIT UNION',
+            'COMMUNICATION FCU':         'COMMUNICATION FEDERAL CREDIT UNION',
+            'WEOKIE FEDERAL CREDIT UNION': 'WEOKIE CREDIT UNION',
+            'WEOKIE':                    'WEOKIE CREDIT UNION',
+            'NAVY FEDERAL CU':           'NAVY FEDERAL CREDIT UNION',
+            'FORT SILL NATIONAL BANK':   'FSNB',
+            'CITY NATIONAL BANK AND TRUST': 'CITY NATIONAL BANK & TRUST',
+            'FIRST NATIONAL BANK AND TRUST': 'FIRST NATIONAL BANK & TRUST',
+            'BOK FINANCIAL':             'BANK OF OKLAHOMA',
+            'BOKF':                      'BANK OF OKLAHOMA',
+            'INTERNATIONAL BANK OF COMMERCE': 'IBC BANK',
+        },
+    },
     '1776': {  # CoastHills (Central Coast, CA)
         'fed_district': '12',
         'credit_unions': [


### PR DESCRIPTION
## Summary
Adds `CLIENT_CONFIGS` entries in `analytics/competition/01_competitor_config.py` for clients
that had **no entry** — so their Competition section was running with empty local CU/bank
patterns and a default Fed District 12 (San Francisco). Surfaced by the 1759 run log on #206.

## Clients added (6)
| ID | Client | Market | Fed District |
|----|--------|--------|--------------|
| 1759 | First Central CU | Waco, TX | 11 (Dallas) |
| 1226 | Ellafi FCU (fmr Seasons FCU) | Middletown, CT | 1 (Boston) |
| 1746 | PrimeTrust FCU | Muncie, IN | 7 (Chicago) |
| 1217 | Pioneer FCU | Mountain Home, ID | 12 (San Francisco) |
| 1780 | USF FCU (now USF CU) | Tampa, FL | 6 (Atlanta) |
| 1766 | Fort Sill FCU | Lawton, OK | 10 (Kansas City) |

Each entry: local `credit_unions` + `local_banks` + abbreviation `rollups`, with `custom: ['USAA']` for the two military-market clients (Tampa MacDill, Fort Sill). Local rosters verified against current sources (chamber listings, institution sites, Wikipedia) — not guessed. District top-25 banks (Frost, Suncoast region nationals, etc.) are left to the existing per-district lists to avoid duplication.

## Safety
- **Fort Sill**: the client is *Fort Sill **Federal Credit Union***; **FSNB / Fort Sill National Bank** is a *separate* bank. Bank patterns are full-string (`FSNB`, `FORT SILL NATIONAL BANK`) so the client never matches itself.
- Validated programmatically: compiles, all Fed districts exist, no orphan rollup targets, no duplicate patterns, no client self-match.

## What the operator sees
Re-running TXN for any of these clients: the `no entry in CLIENT_CONFIGS` warning is gone, the Competition section detects local competitors, and `top_25_fed_district` resolves to the correct region.

## Not included
Remaining IDs in `clients_config.json` (1049, 1121, 1192, 1195, 1554, 1681, 1765, 1795, 1798, 1799, 1807, 1562) were left out per owner — not current/not these CSM's clients.

## From #206 (separate)
- MCC skipping for clients without MCC data is expected (graceful skip).
- TXN eligible-filter is intentionally not enforced; follow-up is to surface `total` vs `eligible` counts for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
