### PR TITLE
Competition: un-blind discovery net + isolate payment ecosystems from headline

### DIFF
--- a/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
+++ b/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
@@ -123,28 +123,6 @@ UNIVERSAL_COMPETITORS = {
         ],
         'exact': [],
     },
-
-    # Crypto exchanges + digital-native investing apps. These pull deposits and
-    # primary-account engagement away from the FI, so they ARE true competitors
-    # (not payment ecosystems). Traditional full-service brokerages (Schwab,
-    # Fidelity, Vanguard, etc.) intentionally live in the Financial Services
-    # section -- keep them there to avoid double-counting; revisit in the FS audit.
-    'crypto_investing': {
-        'starts_with': [
-            'COINBASE', 'COINBASE INC',
-            'ROBINHOOD', 'ROBINHOOD SECURITIES', 'ROBINHOOD CRYPTO', 'ROBINHOOD GOLD',
-            'KRAKEN',
-            'BINANCE', 'BINANCE US', 'BINANCE.US',
-            'CRYPTO.COM', 'CRYPTO COM',
-            'GEMINI TRUST',
-            'BLOCKFI',
-            'WEBULL',
-            'ETORO',
-            'PUBLIC.COM', 'PUBLIC HLDG',
-            'BLOCKCHAIN COM',
-        ],
-        'exact': [],
-    },
 }
 
 UNIVERSAL_ECOSYSTEMS = {

--- a/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
+++ b/01_Analysis/00-Scripts/analytics/competition/01_competitor_config.py
@@ -123,6 +123,28 @@ UNIVERSAL_COMPETITORS = {
         ],
         'exact': [],
     },
+
+    # Crypto exchanges + digital-native investing apps. These pull deposits and
+    # primary-account engagement away from the FI, so they ARE true competitors
+    # (not payment ecosystems). Traditional full-service brokerages (Schwab,
+    # Fidelity, Vanguard, etc.) intentionally live in the Financial Services
+    # section -- keep them there to avoid double-counting; revisit in the FS audit.
+    'crypto_investing': {
+        'starts_with': [
+            'COINBASE', 'COINBASE INC',
+            'ROBINHOOD', 'ROBINHOOD SECURITIES', 'ROBINHOOD CRYPTO', 'ROBINHOOD GOLD',
+            'KRAKEN',
+            'BINANCE', 'BINANCE US', 'BINANCE.US',
+            'CRYPTO.COM', 'CRYPTO COM',
+            'GEMINI TRUST',
+            'BLOCKFI',
+            'WEBULL',
+            'ETORO',
+            'PUBLIC.COM', 'PUBLIC HLDG',
+            'BLOCKCHAIN COM',
+        ],
+        'exact': [],
+    },
 }
 
 UNIVERSAL_ECOSYSTEMS = {
@@ -1054,9 +1076,17 @@ def tag_competitors(df, merchant_col='merchant_consolidated'):
 
 
 _FINANCIAL_KEYWORDS = [
+    # Traditional banking
     'BANK', 'BANKING', 'CREDIT UNION', 'CU ', 'FEDERAL CREDIT',
     'FINANCIAL', 'SAVINGS', 'LENDING', 'MORTGAGE', 'LOAN',
     'BROKERAGE', 'INVESTMENT', 'TRUST COMPANY',
+    # Fintech / crypto / investing -- these brands carry NO 'bank/financial'
+    # token, so the old keyword set silently hid them (e.g. COINBASE), which is
+    # why missed competitors never surfaced in the discovery output. Broadened
+    # so any untagged fintech/crypto/investing leakage shows up for review.
+    'CRYPTO', 'BITCOIN', 'BLOCKCHAIN', 'EXCHANGE', 'WALLET',
+    'SECURITIES', 'BROKER', 'WEALTH', 'ADVISOR', 'CAPITAL MANAGEMENT',
+    'NEOBANK', 'FINTECH', 'PAYMENTS', 'MONEY', 'FUNDING', 'VENTURES',
 ]
 
 def discover_unmatched_financial(df, merchant_col='merchant_consolidated', top_n=20):

--- a/01_Analysis/00-Scripts/analytics/competition/02_competitor_detection.py
+++ b/01_Analysis/00-Scripts/analytics/competition/02_competitor_detection.py
@@ -97,12 +97,20 @@ else:
     true_txns = len(competitor_txns[competitor_txns['competitor_category'].isin(TRUE_COMPETITORS)])
     eco_txns = len(competitor_txns[competitor_txns['competitor_category'].isin(PAYMENT_ECOSYSTEMS)])
 
+    # Headline reach should reflect TRUE competitors (banks/CUs/crypto-investing),
+    # not payment ecosystems. Local temps only -- the all-category vars above stay
+    # intact for the category breakdown panels below.
+    _true_panel    = competitor_txns[competitor_txns['competitor_category'].isin(TRUE_COMPETITORS)]
+    _true_accounts = _true_panel['primary_account_num'].nunique()
+    _pct_true_acct = (_true_accounts / total_accounts * 100) if total_accounts else 0
+    _true_unique   = _true_panel['competitor_match'].nunique()
+
     # --- Panel 1: Detection KPIs ---
     kpis = [
-        (f"{len(combined_df):,}",     "Transactions\nSearched",         GEN_COLORS['info']),
-        (f"{len(competitor_txns):,}",  "Competitor\nTransactions",       GEN_COLORS['accent']),
-        (f"{pct_comp_accounts:.1f}%",  "Accounts with\nCompetitor Activity", GEN_COLORS['accent']),
-        (f"{unique_competitors}",      "Unique\nCompetitors",            GEN_COLORS['warning']),
+        (f"{len(combined_df):,}",      "Transactions\nSearched",              GEN_COLORS['info']),
+        (f"{true_txns:,}",             "Competitor\nTransactions",            GEN_COLORS['accent']),
+        (f"{_pct_true_acct:.1f}%",     "Accounts Using\nCompetitor Banks/CUs", GEN_COLORS['accent']),
+        (f"{_true_unique}",            "Unique\nCompetitors",                 GEN_COLORS['warning']),
     ]
 
     fig, axes = plt.subplots(1, 4, figsize=(20, 4.5))

--- a/01_Analysis/00-Scripts/analytics/competition/07_kpi_dashboard.py
+++ b/01_Analysis/00-Scripts/analytics/competition/07_kpi_dashboard.py
@@ -11,23 +11,42 @@ if len(all_competitor_data) > 0:
     # unique_accounts double-counts any account that uses >1 competitor
     # (drove pct_accounts above 100%). Count distinct accounts once
     # across the whole competitor_txns frame instead.
-    total_competitor_trans    = len(competitor_txns)
-    total_competitor_accounts = competitor_txns['primary_account_num'].nunique()
-    total_competitors_found   = len(all_competitor_data)
+    # Isolate payment ecosystems (wallets/p2p/bnpl) from TRUE competitors
+    # (banks/CUs/crypto-investing). Venmo/PayPal/Zelle/Cash App/BNPL are
+    # near-universal payment apps, not displacement threats -- lumping them in
+    # inflated "% using competitors". Headline = true competitors only; payment
+    # app adoption is reported as its own, clearly-labeled number.
+    try:
+        _true_cats, _eco_cats = list(TRUE_COMPETITORS), list(PAYMENT_ECOSYSTEMS)
+    except NameError:
+        _eco_cats = ['wallets', 'p2p', 'bnpl']
+        _true_cats = [c for c in competitor_txns['competitor_category'].dropna().unique()
+                      if c not in _eco_cats]
+
+    _true_txns = competitor_txns[competitor_txns['competitor_category'].isin(_true_cats)]
+    _eco_txns  = competitor_txns[competitor_txns['competitor_category'].isin(_eco_cats)]
+
+    total_competitor_trans    = len(_true_txns)
+    total_competitor_accounts = _true_txns['primary_account_num'].nunique()
+    total_competitors_found   = _true_txns['competitor_match'].nunique()
 
     total_all_trans    = len(combined_df)
     total_all_accounts = combined_df['primary_account_num'].nunique()
 
-    pct_trans = (total_competitor_trans / total_all_trans * 100) if total_all_trans > 0 else 0
+    pct_trans    = (total_competitor_trans / total_all_trans * 100) if total_all_trans > 0 else 0
     pct_accounts = (total_competitor_accounts / total_all_accounts * 100) if total_all_accounts > 0 else 0
-    avg_txn_per_account = (total_competitor_trans / total_competitor_accounts) if total_competitor_accounts > 0 else 0
 
-    # ----- KPI card layout -----
+    eco_accounts     = _eco_txns['primary_account_num'].nunique()
+    pct_eco_accounts = (eco_accounts / total_all_accounts * 100) if total_all_accounts > 0 else 0
+
+    _muted = GEN_COLORS.get('muted', '#6C757D') if hasattr(GEN_COLORS, 'get') else '#6C757D'
+
+    # ----- KPI card layout (headline = true competitors; payment apps separate) -----
     kpis = [
-        (f"{pct_accounts:.1f}%",   "of Accounts\nUsing Competitors",  GEN_COLORS['accent']),
-        (f"{pct_trans:.1f}%",      "of Transactions\nGo to Competitors", GEN_COLORS['info']),
-        (f"{total_competitors_found}", "Competitors\nDetected",        GEN_COLORS['warning']),
-        (f"{avg_txn_per_account:.1f}", "Avg Transactions\nper Account", GEN_COLORS['success']),
+        (f"{pct_accounts:.1f}%",       "of Accounts Using\nCompetitor Banks/CUs",  GEN_COLORS['accent']),
+        (f"{pct_trans:.1f}%",          "of Transactions\nto Competitors",          GEN_COLORS['info']),
+        (f"{total_competitors_found}", "Competitors\nDetected",                    GEN_COLORS['warning']),
+        (f"{pct_eco_accounts:.1f}%",   "Use Payment Apps\n(not competitors)",      _muted),
     ]
 
     fig, axes = plt.subplots(1, 4, figsize=(18, 5))
@@ -68,10 +87,13 @@ if len(all_competitor_data) > 0:
     plt.tight_layout()
     plt.show()
 
-    # Opportunity callout
+    # Opportunity callout -- based on TRUE competitor reach (banks/CUs/crypto),
+    # not payment-app usage.
     if pct_accounts < 20:
-        print(f"\n    OPPORTUNITY: Only {pct_accounts:.1f}% of accounts show competitor activity.")
+        print(f"\n    OPPORTUNITY: Only {pct_accounts:.1f}% of accounts use a competitor bank/CU.")
         print("    Competitor footprint is limited -- defend these relationships now before it grows.")
     elif pct_accounts > 40:
-        print(f"\n    WARNING: {pct_accounts:.1f}% of accounts show competitor activity.")
+        print(f"\n    WARNING: {pct_accounts:.1f}% of accounts use a competitor bank/CU.")
         print("    Significant competitive overlap -- targeted retention strategy needed.")
+    print(f"    (Payment apps -- Venmo/PayPal/Zelle/Cash App/BNPL -- reach "
+          f"{pct_eco_accounts:.1f}% of accounts; reported separately, not as competitors.)")


### PR DESCRIPTION
## Summary
Two Competition fixes from the #206 investigation, addressing "we're cutting out data" and "payment apps aren't really competitors."

## 1. Un-blind the discovery net
`discover_unmatched_financial` only surfaced untagged merchants whose **name** contained bank/financial keywords — so fintech/crypto brands (COINBASE, ROBINHOOD, etc.) were invisible to detection **and** to the "potential competitors not in config" safety net. A run printed "all financial merchants matched" while silently dropping the whole fintech class. Broadened the keyword set (crypto/fintech/investing terms) so missed leakage surfaces for review every run.

## 2. Isolate payment ecosystems from the headline
The headline "% of accounts using competitors" counted **all** competitor txns, including Venmo/PayPal/Zelle/Cash App/BNPL that nearly everyone uses — inflating exposure (the 68.2% in deck 1759) and conflating payment-app usage with real displacement. `07_kpi_dashboard` and the `02` detection panel now:
- Lead with **true competitors** (banks/CUs)
- Report **payment-app adoption** as a separate, clearly-labeled number ("Use Payment Apps — not competitors")

`competitor_txns` stays the full set, so ecosystem-aware cells (`70_banking_vs_ecosystems`, `33_non_bank_threats`, `66/67` BNPL) are untouched.

## Not included (owner decisions)
- **Crypto stays in Financial Services only** — the FS section already has a 33-pattern Crypto/Digital Assets category, so a separate competition crypto category was dropped to avoid double-counting.
- "Little local / no top-25" in older runs = missing `CLIENT_CONFIGS` entries → fixed for your 6 clients in #207.

## Validation
All changed cells compile; ecosystems stay in wallets/p2p/bnpl; headline split simulated (conflated 50% → 20% true-competitor + 50% payment-app shown separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
