### PR TITLE
Force matplotlib Agg backend in TXN path (fixes parallel-run Tk_GetPixmap crash)

### DIFF
--- a/01_Analysis/00-Scripts/analytics/txn_wrapper.py
+++ b/01_Analysis/00-Scripts/analytics/txn_wrapper.py
@@ -32,6 +32,12 @@ from pathlib import Path
 from typing import Any
 
 import matplotlib
+# Force the non-interactive Agg backend BEFORE pyplot is imported. The pipeline
+# runs headless and in parallel; the default interactive backend (TkAgg on the
+# work PC) exhausts Tk pixmaps under concurrent figure creation -> "Fail to
+# create pixmap with Tk_GetPixmap in TkImgPhotoInstanceSetSize" (issue #214).
+os.environ.setdefault("MPLBACKEND", "Agg")
+matplotlib.use("Agg", force=True)
 import matplotlib.pyplot as plt
 from loguru import logger
 


### PR DESCRIPTION
## Summary
Parallel TXN runs crashed with `Fail to create pixmap with Tk_GetPixmap in TkImgPhotoInstanceSetSize` (#214).

**Root cause:** `txn_wrapper.py` imported `matplotlib.pyplot` at module load **without forcing a backend**, so on the work PC (Tk installed) matplotlib initialized the interactive **TkAgg** backend. Under a parallel run, concurrent figure creation exhausts Tk's pixmap resources → crash. `charts/guards.py` already forces `Agg` for the ARS path, but the TXN path never did.

## Fix
Force the non-interactive `Agg` backend **before** pyplot is imported in `txn_wrapper.py`:
```python
os.environ.setdefault("MPLBACKEND", "Agg")
matplotlib.use("Agg", force=True)
import matplotlib.pyplot as plt
```
`force=True` switches even if a Tk backend was selected upstream; the `MPLBACKEND` env var is belt-and-suspenders for any worker that imports matplotlib first.

## Verification
`matplotlib.get_backend()` resolves to `Agg`; file compiles. (No GUI/display is ever needed — every figure is saved via `ChartCapture`/`savefig`, never shown.)

Closes #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
