### PR TITLE
Formatting: fix CSM source folder + tolerant month-folder resolution (#220)

### DIFF
--- a/00_Formatting/00-Scripts/month_resolver.py
+++ b/00_Formatting/00-Scripts/month_resolver.py
@@ -1,0 +1,86 @@
+"""Tolerant month-folder resolution for CSM source dumps (issue #220).
+
+CSMs name their monthly OD-dump folders inconsistently -- ``2026.06``,
+``2026-06``, ``June, 2026``, ``Jun 2026``, etc. The pipeline always speaks the
+canonical ``YYYY.MM`` month, so when locating a CSM's source folder we parse
+every candidate subfolder into a ``(year, month)`` pair and match on that
+instead of a brittle string compare.
+
+Pure stdlib so it can be imported and unit-tested without the formatting
+pipeline's heavier dependencies.
+"""
+
+from __future__ import annotations
+
+import calendar
+import re
+from pathlib import Path
+
+# Month names and 3-letter abbreviations -> month number.
+_MONTH_LOOKUP: dict[str, int] = {}
+for _i in range(1, 13):
+    _MONTH_LOOKUP[calendar.month_name[_i].lower()] = _i
+    _MONTH_LOOKUP[calendar.month_abbr[_i].lower()] = _i
+
+# Longest-first so "june" wins over the "jun" abbreviation.
+_MONTH_WORD_RE = re.compile(
+    r"\b(" + "|".join(sorted(_MONTH_LOOKUP, key=len, reverse=True)) + r")\b"
+)
+_YEAR_RE = re.compile(r"\b(20\d{2})\b")
+# YYYY<sep>MM (sep required so a bare year doesn't grab an unrelated digit).
+_NUM_YM_RE = re.compile(r"\b(20\d{2})[._\-/ ](\d{1,2})\b")
+# MM<sep>YYYY (month-first numeric form, e.g. 06.2026).
+_NUM_MY_RE = re.compile(r"\b(\d{1,2})[._\-/ ](20\d{2})\b")
+
+
+def parse_year_month(name: str):
+    """Parse a folder name into ``(year, month)``, or ``None`` if it encodes no
+    month. Handles numeric (``2026.06``, ``2026-06``, ``06.2026``) and
+    month-name (``June, 2026``, ``Jun 2026``) forms."""
+    if not name:
+        return None
+    s = name.strip().lower()
+
+    m = _NUM_YM_RE.search(s)
+    if m:
+        year, month = int(m.group(1)), int(m.group(2))
+        if 1 <= month <= 12:
+            return (year, month)
+
+    m = _NUM_MY_RE.search(s)
+    if m:
+        month, year = int(m.group(1)), int(m.group(2))
+        if 1 <= month <= 12:
+            return (year, month)
+
+    wm = _MONTH_WORD_RE.search(s)
+    ym = _YEAR_RE.search(s)
+    if wm and ym:
+        return (int(ym.group(1)), _MONTH_LOOKUP[wm.group(1)])
+
+    return None
+
+
+def resolve_source_month_dir(base, month):
+    """Return the month subfolder under ``base`` matching the canonical
+    ``YYYY.MM`` ``month``, tolerating per-CSM folder naming.
+
+    Falls back to ``base / month`` when ``base`` is missing, ``month`` is
+    unparseable, or nothing matches -- so a caller's "source not found"
+    message still points at the expected canonical path.
+    """
+    base = Path(base)
+    target = parse_year_month(month)
+    default = base / month
+    if target is None or not base.exists():
+        return default
+    # Canonical folder present -> use it (no scan; preserves prior behavior).
+    if default.is_dir():
+        return default
+    for child in sorted(base.iterdir()):
+        try:
+            if child.is_dir() and parse_year_month(child.name) == target:
+                return child
+        except OSError:
+            continue
+    return default

--- a/00_Formatting/run.py
+++ b/00_Formatting/run.py
@@ -35,6 +35,7 @@ _config_dir = Path(__file__).resolve().parent.parent / "03_Config"
 sys.path.insert(0, str(_config_dir))
 
 import pandas as pd
+from month_resolver import resolve_source_month_dir
 from settings import load_settings
 from shared.format_odd import format_odd
 
@@ -484,7 +485,11 @@ def main():
 
     def _process_one_csm(csm_name, csm_source):
         """Process a single CSM -- can be called in parallel."""
-        src = Path(csm_source) / month
+        # CSMs name their monthly dump folders inconsistently ("2026.06",
+        # "June, 2026", ...), so resolve the source month folder by parsing
+        # candidates rather than assuming the canonical name (issue #220).
+        # Our own staging/output dirs stay normalized to the canonical month.
+        src = resolve_source_month_dir(csm_source, month)
         staging = staging_base / csm_name / month
         output = output_base / csm_name / month
 

--- a/01_Analysis/00-Scripts/tests/test_month_resolver.py
+++ b/01_Analysis/00-Scripts/tests/test_month_resolver.py
@@ -1,0 +1,75 @@
+"""Month-folder resolution for CSM source dumps (issue #220).
+
+CSMs name their monthly OD-dump folders inconsistently ('2026.06', 'June, 2026',
+...). The resolver maps the canonical YYYY.MM the pipeline speaks onto whatever
+folder the CSM actually created.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "00_Formatting" / "00-Scripts" / "month_resolver.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("month_resolver", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mr = _load()
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("2026.06", (2026, 6)),
+    ("2026-06", (2026, 6)),
+    ("2026_06", (2026, 6)),
+    ("2026.6", (2026, 6)),
+    ("June, 2026", (2026, 6)),
+    ("June 2026", (2026, 6)),
+    ("Jun 2026", (2026, 6)),
+    ("06.2026", (2026, 6)),
+    ("December, 2026", (2026, 12)),
+    ("2026", None),          # year only -> no month
+    ("ODDD archive", None),  # no date at all
+    ("", None),
+])
+def test_parse_year_month(name, expected):
+    assert mr.parse_year_month(name) == expected
+
+
+def test_resolve_matches_month_name_folder(tmp_path):
+    """The #220 case: canonical 2026.06 -> 'June, 2026' on disk."""
+    (tmp_path / "June, 2026").mkdir()
+    (tmp_path / "May, 2026").mkdir()
+    assert mr.resolve_source_month_dir(tmp_path, "2026.06") == tmp_path / "June, 2026"
+
+
+def test_resolve_prefers_canonical_when_present(tmp_path):
+    (tmp_path / "2026.06").mkdir()
+    (tmp_path / "June, 2026").mkdir()
+    assert mr.resolve_source_month_dir(tmp_path, "2026.06") == tmp_path / "2026.06"
+
+
+def test_resolve_handles_dashed_folder(tmp_path):
+    (tmp_path / "2026-06").mkdir()
+    assert mr.resolve_source_month_dir(tmp_path, "2026.06") == tmp_path / "2026-06"
+
+
+def test_resolve_falls_back_when_no_match(tmp_path):
+    # base exists but no matching month -> canonical path (keeps 'not found' msg honest)
+    (tmp_path / "April, 2026").mkdir()
+    assert mr.resolve_source_month_dir(tmp_path, "2026.06") == tmp_path / "2026.06"
+
+
+def test_resolve_falls_back_when_base_missing(tmp_path):
+    missing = tmp_path / "nope"
+    assert mr.resolve_source_month_dir(missing, "2026.06") == missing / "2026.06"

--- a/03_Config/ars_config.json
+++ b/03_Config/ars_config.json
@@ -14,7 +14,7 @@
     "csm_sources": {
         "sources": {
             "JamesG": "M:\\JamesG\\OD Data Dumps",
-            "Jordan": "M:\\Jordan\\OD Data Dumps",
+            "Jordan": "M:\\JBerkowitz\\OD Data Dumps",
             "Aaron": "M:\\Aaron\\OD Data Dumps",
             "Gregg": "M:\\Gregg\\OD Data Dumps",
             "Dan": "M:\\Dan\\OD Data Dumps",


### PR DESCRIPTION
## Problem (#220)
Step-1 formatting for **Jordan / 2026.06 / 1554** failed: `Source not found: M:\Jordan\OD Data Dumps\2026.06`. Two distinct mismatches between what the code builds and what's on the M: drive:

1. **Wrong CSM source folder.** `ars_config.json` mapped `Jordan → M:\Jordan\…`, but the real folder is `M:\JBerkowitz\…`. The convention is inconsistent across CSMs (`JamesG` → `JamesG`, but `Jordan` → `JBerkowitz`).
2. **Month folder naming differs per CSM.** `run.py` appended the canonical month literally (`2026.06`), but JBerkowitz's folders look like `June, 2026` (and JamesG's like `2026.04`). No conversion existed.

## Fix
- **Config:** `Jordan` → `M:\JBerkowitz\OD Data Dumps`.
- **`run.py`:** resolve the source month folder via new `month_resolver.resolve_source_month_dir(base, month)` — it scans the CSM's dump folder and matches the requested month by **parsing each subfolder into `(year, month)`**, tolerating `2026.06`, `2026-06`, `June, 2026`, `Jun 2026`, `06.2026`, etc. Prefers the canonical folder when present; falls back to the canonical path (so "not found" stays honest). Our staging/output dirs remain normalized to `YYYY.MM`.
- `month_resolver` is **pure stdlib** and unit-tested (parse + resolve, including the `1554`/`June, 2026` case). **Full suite: 207 passed.**

## Still needs your input (real M: drive)
- Verify the other CSM source folders — **Aaron / Gregg / Dan / Max** — match reality (Jordan's was wrong; others may be too).
- The `extra_files.workbook_csm_folder` map (R: drive) has the same risk.

## Verify (work PC)
Re-run **Jordan / 2026.06 / 1554** from the UI. The source should resolve to `M:\JBerkowitz\OD Data Dumps\June, 2026`, find `1554_ODDD.zip`, and format > 0 files.

Refs #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)