### PR TITLE
feat(install): self-contained Python bundle so CSMs can launch without Python

### DIFF
--- a/.github/workflows/build-python-bundle.yml
+++ b/.github/workflows/build-python-bundle.yml
@@ -1,0 +1,69 @@
+name: Build Python Bundle
+
+# Builds a self-contained Windows Python (interpreter + every package in
+# requirements.txt) and publishes it as the "python-bundle" release asset.
+# "CSM Setup.bat" downloads that asset onto each CSM machine.
+#
+# Run it: Actions tab -> "Build Python Bundle" -> "Run workflow".
+# It also rebuilds automatically whenever requirements.txt changes.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - requirements.txt
+      - .github/workflows/build-python-bundle.yml
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download standalone CPython (Windows x64, relocatable)
+        shell: pwsh
+        run: |
+          $headers = @{ "User-Agent" = "velocity-bundle"; "Authorization" = "Bearer $env:GH_TOKEN" }
+          $rel = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest"
+          $asset = $rel.assets |
+            Where-Object { $_.name -like "cpython-3.12.*-x86_64-pc-windows-msvc-install_only.tar.gz" } |
+            Select-Object -First 1
+          if (-not $asset) { throw "No matching CPython install_only asset found" }
+          Write-Host "Downloading $($asset.name)"
+          Invoke-WebRequest -Headers $headers -Uri $asset.browser_download_url -OutFile cpython.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract CPython
+        shell: pwsh
+        run: |
+          tar -xzf cpython.tar.gz   # extracts to .\python\
+          .\python\python.exe --version
+
+      - name: Install packages into the bundle
+        shell: pwsh
+        run: |
+          .\python\python.exe -m pip install --upgrade pip
+          .\python\python.exe -m pip install -r requirements.txt
+          .\python\python.exe -c "import fastapi, pandas, numpy, matplotlib, pptx, openpyxl, xlsxwriter; print('verify ok')"
+
+      - name: Zip the bundle (python\ at archive root)
+        shell: pwsh
+        run: |
+          Compress-Archive -Path python -DestinationPath Velocity-Python.zip -Force
+          $size = [math]::Round((Get-Item Velocity-Python.zip).Length / 1MB, 1)
+          Write-Host "Velocity-Python.zip = $size MB"
+
+      - name: Publish to the python-bundle release
+        shell: pwsh
+        run: |
+          gh release delete python-bundle --yes 2>$null
+          gh release create python-bundle Velocity-Python.zip `
+            --title "Velocity Python Bundle" `
+            --notes "Self-contained Windows Python + packages for CSM machines. Built from requirements.txt. Downloaded by 'CSM Setup.bat'."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-python-bundle.yml
+++ b/.github/workflows/build-python-bundle.yml
@@ -30,9 +30,13 @@ jobs:
           $headers = @{ "User-Agent" = "velocity-bundle"; "Authorization" = "Bearer $env:GH_TOKEN" }
           $rel = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest"
           $asset = $rel.assets |
-            Where-Object { $_.name -like "cpython-3.12.*-x86_64-pc-windows-msvc-install_only.tar.gz" } |
+            Where-Object {
+              $_.name -like "cpython-3.12.*windows*install_only.tar.gz" -and
+              $_.name -like "*x86_64*" -and
+              $_.name -notlike "*stripped*"
+            } |
             Select-Object -First 1
-          if (-not $asset) { throw "No matching CPython install_only asset found" }
+          if (-not $asset) { throw "No matching CPython 3.12 windows install_only asset found" }
           Write-Host "Downloading $($asset.name)"
           Invoke-WebRequest -Headers $headers -Uri $asset.browser_download_url -OutFile cpython.tar.gz
         env:
@@ -61,9 +65,17 @@ jobs:
       - name: Publish to the python-bundle release
         shell: pwsh
         run: |
-          gh release delete python-bundle --yes 2>$null
-          gh release create python-bundle Velocity-Python.zip `
-            --title "Velocity Python Bundle" `
-            --notes "Self-contained Windows Python + packages for CSM machines. Built from requirements.txt. Downloaded by 'CSM Setup.bat'."
+          # PowerShell 7 throws on any non-zero native exit; disable that so we
+          # can probe whether the release already exists without failing.
+          $PSNativeCommandUseErrorActionPreference = $false
+          gh release view python-bundle 1>$null 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Release exists - replacing the asset"
+            gh release upload python-bundle Velocity-Python.zip --clobber
+          } else {
+            Write-Host "Creating the python-bundle release"
+            gh release create python-bundle Velocity-Python.zip --title "Velocity Python Bundle" --notes "Self-contained Windows Python + packages for CSM machines. Built from requirements.txt. Downloaded by 'CSM Setup.bat'."
+          }
+          if ($LASTEXITCODE -ne 0) { throw "Release publish failed" }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CSM Setup.bat
+++ b/CSM Setup.bat
@@ -1,0 +1,82 @@
+@echo off
+title CSM Setup - Velocity Pipeline
+color 0B
+
+echo.
+echo ======================================================================
+echo   VELOCITY PIPELINE - One-time setup
+echo ======================================================================
+echo.
+echo   This installs everything the tool needs on THIS computer.
+echo   It runs ONCE. You will not need to do this again.
+echo.
+echo   You can leave it running - it will say "Done" when it finishes.
+echo   This can take a few minutes the first time.
+echo.
+
+set "TARGET=%LOCALAPPDATA%\Velocity"
+set "ZIP=%TEMP%\Velocity-Python.zip"
+set "URL=https://github.com/JG-CSI-Velocity/ars-production-pipeline/releases/download/python-bundle/Velocity-Python.zip"
+
+REM --- Already set up? Skip straight to Done. ---
+if exist "%TARGET%\python\python.exe" (
+    color 0A
+    echo   This computer is already set up. Nothing to do.
+    echo.
+    echo   Done. You can close this window and double-click "Start Here.bat".
+    pause >nul
+    exit /b 0
+)
+
+echo   [1 of 3] Downloading ^(one time, a few hundred MB^)...
+powershell -NoProfile -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%URL%' -OutFile '%ZIP%' -UseBasicParsing } catch { Write-Host $_.Exception.Message; exit 1 }"
+if errorlevel 1 goto fail_download
+
+echo   [2 of 3] Installing ^(unpacking files^)...
+if not exist "%TARGET%" mkdir "%TARGET%"
+powershell -NoProfile -Command "try { Expand-Archive -Path '%ZIP%' -DestinationPath '%TARGET%' -Force } catch { Write-Host $_.Exception.Message; exit 1 }"
+if errorlevel 1 goto fail_unzip
+
+echo   [3 of 3] Checking the install...
+"%TARGET%\python\python.exe" -c "import fastapi, pandas, numpy, matplotlib, pptx; print('ok')" >nul 2>nul
+if errorlevel 1 goto fail_verify
+
+del "%ZIP%" >nul 2>nul
+
+color 0A
+echo.
+echo ======================================================================
+echo   Done. This computer is ready.
+echo   Close this window and double-click "Start Here.bat".
+echo ======================================================================
+pause >nul
+exit /b 0
+
+:fail_download
+color 0C
+echo.
+echo   COULD NOT DOWNLOAD the setup file.
+echo     - Check that you have internet access and try again.
+echo     - If it keeps failing, screenshot this window and send it to James.
+echo.
+pause >nul
+exit /b 1
+
+:fail_unzip
+color 0C
+echo.
+echo   COULD NOT UNPACK the setup file.
+echo     - Try running "CSM Setup.bat" again.
+echo     - If it keeps failing, screenshot this window and send it to James.
+echo.
+pause >nul
+exit /b 1
+
+:fail_verify
+color 0C
+echo.
+echo   Setup finished but a final check failed.
+echo     - Screenshot this window and send it to James.
+echo.
+pause >nul
+exit /b 1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,106 @@
+# Installing the Velocity Pipeline
+
+There are two parts here. **CSMs only ever read the first part.** The second
+part is for James — how it actually works and how to rebuild the bundle.
+
+---
+
+## For CSMs — getting set up (read this only)
+
+You open the same shared folder you always open. Two files matter:
+
+| File | When you use it |
+|---|---|
+| **`CSM Setup.bat`** | Double-click **once**, the very first day. |
+| **`Start Here.bat`** | Double-click **every time** you want to use the tool. |
+
+### The first day (once)
+
+1. Double-click **`CSM Setup.bat`**.
+2. Wait until it says **`Done`** (a few minutes — it's downloading once).
+3. Close that window.
+
+### Every day after that
+
+1. Double-click **`Start Here.bat`**.
+2. The tool opens in your browser.
+
+That's it. You never type anything, never open a black command window, and
+never install Python yourself.
+
+### If something goes wrong
+
+- **`Start Here.bat` says "This computer has not been set up yet"** → you
+  skipped the first day. Double-click `CSM Setup.bat` once, wait for `Done`,
+  then try `Start Here.bat` again.
+- **`CSM Setup.bat` says it couldn't download** → check your internet and run
+  it again. If it still fails, screenshot the window and send it to James.
+
+---
+
+## For James — how it works and how to rebuild
+
+### The idea
+
+The CSM machines don't have Python, or have Python but none of our packages
+(see issue #226 — one machine had Python 3.12 but `ModuleNotFoundError: No
+module named 'fastapi'`). Rather than install Python on every machine by hand,
+we ship a **self-contained Python** — interpreter plus all 14 packages from
+`requirements.txt` — and the launcher uses *that* instead of the system Python.
+
+Two locations, and only two:
+
+| What | Where | Changes |
+|---|---|---|
+| Python + all packages | **Local** on each machine: `%LOCALAPPDATA%\Velocity\python\` | Once, dropped by `CSM Setup.bat` |
+| Code, data, outputs, the `.bat` files | **On the share**: `\\PADMIS105\Velocity_Company\ARS\` | Weekly, centrally (unchanged) |
+
+The interpreter goes **local** because loading pandas / numpy / matplotlib
+(thousands of files) over the network share on every launch is slow. The code
+and data stay **on the share** so the weekly update flow and the `code:`
+version stamp are untouched. Nothing needs admin rights — `%LOCALAPPDATA%` is
+always writable by the user.
+
+### The three pieces
+
+1. **`CSM Setup.bat`** (repo root) — downloads the bundle and unpacks it to
+   `%LOCALAPPDATA%\Velocity\`. Idempotent: if it's already installed it just
+   says `Done`.
+2. **`Start Here.bat`** (repo root, rewritten) — runs the server with the
+   bundled Python (`%LOCALAPPDATA%\Velocity\python\python.exe`). Also fixed the
+   real bug from #226: it used `cd /d` on the `\\PADMIS105\...` UNC path, which
+   Windows silently refuses, dropping the user into `C:\Windows\System32`. Now
+   uses `pushd`, which maps a temp drive for UNC paths.
+3. **`.github/workflows/build-python-bundle.yml`** — builds the bundle in the
+   cloud on a Windows runner and publishes it as the `python-bundle` release
+   asset. You never need a Windows machine to produce it.
+
+### Rebuilding the bundle (when requirements.txt changes)
+
+It rebuilds automatically when you push a change to `requirements.txt`. To
+build it by hand: **GitHub → Actions tab → "Build Python Bundle" → Run
+workflow.** When it finishes, the new bundle is the `python-bundle` release
+asset, and `CSM Setup.bat` will pick it up on the next run.
+
+The download URL baked into `CSM Setup.bat` is a **fixed tag** on purpose:
+
+```
+https://github.com/JG-CSI-Velocity/ars-production-pipeline/releases/download/python-bundle/Velocity-Python.zip
+```
+
+Not `releases/latest/...` — "latest" points at whatever the most recent
+release is (right now that's `deck-polish-v0.1.0-pre`), which is the wrong file.
+
+### When a CSM needs the new bundle
+
+Code updates (the weekly `.py` changes) need **nothing** new from the CSM — the
+bundle only holds third-party packages. A CSM re-runs `CSM Setup.bat` **only**
+when the package list itself changes. To force a clean reinstall, delete
+`%LOCALAPPDATA%\Velocity\` and run `CSM Setup.bat` again.
+
+### Not yet verified on Windows
+
+The two `.bat` files and the workflow were written on macOS and have **not**
+been run on a real Windows/UNC machine yet. First real tests:
+1. Trigger the workflow and confirm `Velocity-Python.zip` publishes.
+2. Run `CSM Setup.bat` then `Start Here.bat` on one CSM machine.

--- a/Start Here.bat
+++ b/Start Here.bat
@@ -10,16 +10,39 @@ echo.
 echo   (Keep this window open while using the UI)
 echo.
 
-cd /d "%~dp005_UI"
+REM --- Find the Python bundle installed by "CSM Setup.bat" ---
+set "VELOCITY_PY=%LOCALAPPDATA%\Velocity\python\python.exe"
+if not exist "%VELOCITY_PY%" (
+    color 0C
+    echo   This computer has not been set up yet.
+    echo.
+    echo   Please double-click "CSM Setup.bat" once and wait for "Done",
+    echo   then run "Start Here.bat" again.
+    echo.
+    pause >nul
+    exit /b 1
+)
 
-:: Start the server in the background
-start /b python app.py
+REM --- Move into the UI folder.
+REM     pushd maps a temporary drive letter for \\network\share paths,
+REM     which plain "cd /d" cannot do - that was the old failure. ---
+pushd "%~dp005_UI"
+if errorlevel 1 (
+    color 0C
+    echo   Could not open the 05_UI folder.
+    echo   Is the network drive / share connected?
+    echo.
+    pause >nul
+    exit /b 1
+)
 
-:: Wait for the server to be ready (uses PowerShell, no curl dependency)
+REM --- Start the server in the background using the bundled Python ---
+start "" /b "%VELOCITY_PY%" app.py
+
 echo   Waiting for server...
 :wait_loop
 timeout /t 2 /nobreak >nul
-powershell -Command "try { $r = Invoke-WebRequest -Uri 'http://localhost:8000' -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop; exit 0 } catch { exit 1 }" >nul 2>nul
+powershell -NoProfile -Command "try { Invoke-WebRequest -Uri 'http://localhost:8000' -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop > $null; exit 0 } catch { exit 1 }" >nul 2>nul
 if errorlevel 1 goto wait_loop
 
 echo   Server ready! Opening browser...
@@ -31,5 +54,5 @@ echo ======================================================================
 
 start http://localhost:8000
 
-:: Keep the window open (server runs in background)
+REM Keep the window (and the temp drive mapping the server runs from) open.
 pause >nul

--- a/docs/superpowers/specs/2026-06-16-csm-python-bundle-install-design.md
+++ b/docs/superpowers/specs/2026-06-16-csm-python-bundle-install-design.md
@@ -1,0 +1,87 @@
+# CSM Python Bundle Install — Design
+
+**Date:** 2026-06-16
+**Status:** Approved (verbal), implementation on branch `feat/csm-python-bundle`
+**Issue:** #226 (csm install issue)
+
+## Problem
+
+CSMs cannot launch the UI. `Start Here.bat` runs the system `python`, which on
+their machines is either absent or present-but-without-our-packages. Issue #226
+shows a machine with Python 3.12.10 installed but `ModuleNotFoundError: No
+module named 'fastapi'`. The same screenshot reveals two more facts:
+
+- The repo is accessed over a **UNC path** (`\\PADMIS105\Velocity_Company\ARS\`),
+  not always a mapped `M:` drive.
+- CSMs don't know how to launch it — they paste the file path into the Python
+  REPL (`SyntaxError`) and into CMD instead of using `Start Here.bat`.
+
+Constraints: non-technical operators; no admin rights (plan for it); internet
+available; **all inputs/outputs/code live on the network share**; large data
+(100k–160k rows) where speed matters; the code must stay as plain `.py` files
+so the weekly update flow and the `code:` version stamp keep working.
+
+## Decision
+
+Ship a **self-contained, relocatable Windows Python** (interpreter + all 14
+`requirements.txt` packages) and have the launcher use it instead of the system
+Python. Split by change-frequency and by what the network is slow at:
+
+| Concern | Location | Rationale |
+|---|---|---|
+| Python + packages | **Local**: `%LOCALAPPDATA%\Velocity\python\` | Big, file-heavy, slow over SMB; rarely changes; no admin needed |
+| Code, data, outputs, `.bat`s | **Share** (unchanged) | Central weekly updates; system of record; `code:` stamp intact |
+
+Rejected alternatives: PyInstaller `.exe` (fragile with pandas/matplotlib/pptx,
+and freezes the weekly code updates); `uv` bootstrap (elegant but per-machine
+online first-run and a hidden cache location, which works against the operator's
+need to understand where things live); scripted per-user `pip install` (most
+"where did it go" confusion; assumes Python already present).
+
+### Speed note
+
+Packaging carries **zero compute penalty** — a relocatable CPython runs the same
+compiled wheels as an installed one. 160k rows is a seconds-scale vectorized
+pandas workload. If a *run* is slow, the lever is the analysis code + share I/O
+(re-reading `.xlsx` via openpyxl, repeated reads, per-file network round-trips),
+which is a separate profiling task, not a packaging concern.
+
+## Components
+
+1. **`CSM Setup.bat`** (root) — one-time, idempotent. Downloads the bundle from
+   the fixed-tag release and `Expand-Archive`s it to `%LOCALAPPDATA%\Velocity\`.
+   Verifies by importing fastapi/pandas/numpy/matplotlib/pptx. Plain-English
+   failure messages.
+2. **`Start Here.bat`** (root, rewritten) — runs the server with the bundled
+   interpreter; clear message if setup hasn't run. **UNC fix:** `pushd "%~dp0..."`
+   replaces `cd /d`, which Windows refuses on UNC paths (the #226 root cause).
+   The temp drive mapping is left in place for the server's lifetime (no `popd`
+   before `pause`).
+3. **`.github/workflows/build-python-bundle.yml`** — Windows runner downloads
+   the latest `astral-sh/python-build-standalone` `install_only` x64 CPython,
+   pip-installs `requirements.txt` into it, zips with `python\` at the archive
+   root, and publishes to the **fixed `python-bundle` release tag**. Triggered
+   manually or on `requirements.txt` change. No local Windows machine required.
+4. **`INSTALL.md`** — two-step CSM guide + operator "how it works / rebuild".
+
+## Contracts
+
+- Bundle archive root contains `python\python.exe` (matches both the workflow's
+  `Compress-Archive -Path python` and Setup's `Expand-Archive` + the launcher's
+  `%LOCALAPPDATA%\Velocity\python\python.exe`).
+- Download URL is the fixed tag, **not** `releases/latest` (latest currently
+  points at `deck-polish-v0.1.0-pre`).
+- No admin: everything lands under `%LOCALAPPDATA%`.
+
+## Verification (not yet done — authored on macOS)
+
+1. Trigger the workflow; confirm `Velocity-Python.zip` publishes to
+   `python-bundle`.
+2. On one CSM machine: `CSM Setup.bat` → `Done`; `Start Here.bat` → UI opens;
+   confirm it works from the `\\PADMIS105\...` UNC path, not just a mapped drive.
+
+## Out of scope
+
+Run-time performance optimization of the analysis pipeline (separate profiling
+effort). UI-First rule does not apply: this is the pre-UI bootstrap that lets
+the UI launch at all.


### PR DESCRIPTION
## What the operator sees

CSMs open the same shared folder they always open. Two files matter now:

- **`CSM Setup.bat`** — double-click **once**, the first day. Waits for `Done`.
- **`Start Here.bat`** — double-click **every day** to open the tool.

No typing, no command windows, no installing Python by hand.

## Why

Issue #226: CSM machines either have no Python or have Python without our
packages (the screenshot shows Python 3.12 present but `ModuleNotFoundError:
No module named 'fastapi'`). We now ship a self-contained Windows Python
(interpreter + every `requirements.txt` package) and the launcher uses that.

## How it works

| What | Where |
|---|---|
| Python + packages | **Local** per machine: `%LOCALAPPDATA%\Velocity\python\` (no admin) |
| Code, data, outputs | **Share** (`\\PADMIS105\...`), unchanged |

The big file-heavy interpreter goes local so it isn't loaded over SMB on every
launch; code/data stay on the share so weekly updates and the `code:` stamp are
untouched.

## Changes

- `CSM Setup.bat` — one-time idempotent installer; downloads the bundle from the
  fixed `python-bundle` release tag, unpacks to `%LOCALAPPDATA%\Velocity\`.
- `Start Here.bat` — runs the bundled interpreter; **fixes the #226 UNC bug**
  (`cd /d` silently fails on `\\PADMIS105\...`; now `pushd`).
- `.github/workflows/build-python-bundle.yml` — Windows-runner build of the
  bundle, published as the `python-bundle` release asset. No local Windows box
  needed.
- `INSTALL.md` — plain CSM guide + operator rebuild notes.
- Design spec under `docs/superpowers/specs/`.

## Not yet verified (authored on macOS)

1. Trigger **Actions → Build Python Bundle** and confirm `Velocity-Python.zip`
   publishes to the `python-bundle` release.
2. On one CSM machine: `CSM Setup.bat` → `Done`, then `Start Here.bat` → UI
   opens — confirm from the `\\PADMIS105\...` UNC path, not just a mapped drive.

Addresses #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)