### PR TITLE
feat: generate a deck directly from a file/folder path (#229)

### DIFF
--- a/00_Formatting/00-Scripts/tests/test_source_file.py
+++ b/00_Formatting/00-Scripts/tests/test_source_file.py
@@ -1,0 +1,72 @@
+"""Tests for the #229 source-file staging path in 00_Formatting/run.py.
+
+Covers the three behaviors the UI 'Generate from a path' flow relies on:
+  - a raw ODD CSV is run through the 7-step formatter (signature columns appear)
+  - the 4-row preamble is skipped and the index column dropped
+  - a file that doesn't look like a raw ODD is refused, not silently mangled
+"""
+
+import csv
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+_RUN_PY = Path(__file__).resolve().parents[2] / "run.py"
+
+
+def _load_run():
+    spec = importlib.util.spec_from_file_location("ars_run_under_test", _RUN_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_raw_odd(path):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        for i in range(4):  # 4 preamble/metadata rows above the real header
+            w.writerow([f"preamble {i}"])
+        w.writerow(["", "Account", "Stat Code", "DOB", "Date Opened",
+                    "Jun26 PIN $", "Jun26 Sig $", "Jun26 PIN #", "Jun26 Sig #",
+                    "Jun26 Mail", "Jun26 Resp"])
+        w.writerow([0, "1001", "2", "1980-01-01", "2010-05-01", 100, 50, 4, 2, "TH-10", "NU 5+"])
+        w.writerow([1, "1002", "3", "1975-06-15", "2015-03-20", 0, 0, 0, 0, "", ""])
+
+
+def test_raw_csv_is_fully_formatted(tmp_path):
+    run = _load_run()
+    src = tmp_path / "1815-2026-06-FedChoice FCU-ODD.csv"
+    _write_raw_odd(src)
+    out = tmp_path / "out"
+
+    ok, err = run.process_source_file(str(src), "Dan", "2026.06", "1815", str(out), force=True)
+
+    assert (ok, err) == (1, 0)
+    xlsx = list((out / "1815").glob("*.xlsx"))
+    assert len(xlsx) == 1
+    df = pd.read_excel(xlsx[0])
+    # 7-step formatter signature columns must be present
+    for col in ("Total Spend", "Total Swipes", "SwipeCat12", "Response Grouping"):
+        assert col in df.columns, f"missing {col}"
+    # index column dropped, real data preserved (2 rows)
+    assert len(df) == 2
+    assert "Account" in df.columns
+
+
+def test_non_odd_csv_is_refused(tmp_path):
+    run = _load_run()
+    src = tmp_path / "9999-2026-06-junk-ODD.csv"
+    with open(src, "w", newline="") as f:
+        w = csv.writer(f)
+        for i in range(4):
+            w.writerow([f"preamble {i}"])
+        w.writerow(["foo", "bar", "baz"])  # not an ODD header
+        w.writerow([1, 2, 3])
+    out = tmp_path / "out"
+
+    ok, err = run.process_source_file(str(src), "Dan", "2026.06", "9999", str(out), force=True)
+
+    # sanity guard refuses rather than writing a garbage workbook
+    assert (ok, err) == (0, 1)
+    assert not list((out / "9999").glob("*.xlsx"))

--- a/00_Formatting/run.py
+++ b/00_Formatting/run.py
@@ -37,7 +37,7 @@ sys.path.insert(0, str(_config_dir))
 import pandas as pd
 from month_resolver import resolve_source_month_dir
 from settings import load_settings
-from shared.format_odd import format_odd
+from shared.format_odd import check_odd_formatted, format_odd
 
 
 def log_message(message, log_file=None):
@@ -202,6 +202,123 @@ def process_csm(csm_name, src_directory, staging_directory, output_directory, lo
 
         except Exception as e:
             log_message(f"    ERROR formatting {csv_file}: {e}", log_file)
+            error_count += 1
+
+    return success_count, error_count
+
+
+# ─── SINGLE-FILE / FOLDER STAGING (issue #229) ─────────────────────────
+
+# Column signals that indicate a real raw ODD header (used to sanity-check
+# that we skipped the right number of preamble rows before formatting).
+_RAW_ODD_NAME_SIGNALS = ("Stat Code", "Account", "DOB", "Date Opened", "Status", "Product")
+_RAW_ODD_SUFFIX_SIGNALS = (" PIN $", " Sig $", " Mail", " Resp", "MTD")
+
+
+def _looks_like_raw_odd(df):
+    """Heuristic: do these columns look like a real raw ODD header?
+
+    Guards against a wrong ``skiprows`` eating real data -- if the header still
+    looks like metadata (all 'Unnamed', or none of the known ODD signals), we
+    refuse to format rather than emit a garbage workbook.
+    """
+    cols = [str(c) for c in df.columns]
+    if not cols or all(c.startswith("Unnamed") for c in cols):
+        return False
+    if any(sig in cols for sig in _RAW_ODD_NAME_SIGNALS):
+        return True
+    if any(c.endswith(_RAW_ODD_SUFFIX_SIGNALS) for c in cols):
+        return True
+    return False
+
+
+def process_source_file(source_path, csm_name, month, client_id, output_directory, log_file=None, force=False):
+    """Format an explicitly-provided ODD file (or folder of them) into the
+    canonical output layout, bypassing the ZIP auto-scan.
+
+    Used by the UI "Generate from a path" flow (issue #229) for CSMs whose raw
+    dump folder isn't auto-discoverable. Reuses the exact same formatting the
+    ZIP path uses: skip 4 preamble rows -> drop the index column -> the 7-step
+    ``format_odd`` -> write .xlsx. Already-formatted files are placed as-is so
+    they're never double-formatted.
+
+    Returns (success_count, error_count).
+    """
+    src = Path(source_path)
+    if not src.exists():
+        log_message(f"  Source path not found: {src}", log_file)
+        return 0, 1
+
+    if src.is_file():
+        files = [src]
+    else:
+        files = sorted(
+            p for p in src.iterdir()
+            if p.is_file() and p.suffix.lower() in (".csv", ".xlsx") and "odd" in p.name.lower()
+        )
+        if not files:
+            log_message(f"  No .csv/.xlsx ODD files found in folder: {src}", log_file)
+            return 0, 1
+
+    client_output_dir = os.path.join(output_directory, client_id)
+    os.makedirs(client_output_dir, exist_ok=True)
+
+    success_count = 0
+    error_count = 0
+    for fp in files:
+        try:
+            output_path = os.path.join(client_output_dir, fp.stem + ".xlsx")
+
+            if not force and os.path.exists(output_path) and os.path.getsize(output_path) > 10000:
+                log_message(f"    Skipping {fp.name} -- already present ({os.path.getsize(output_path) / 1024 / 1024:.1f} MB)", log_file)
+                continue
+
+            # Already formatted? Place it without re-running format_odd.
+            try:
+                already_formatted = check_odd_formatted(str(fp)).is_formatted
+            except Exception:
+                already_formatted = False
+
+            if already_formatted:
+                if fp.suffix.lower() == ".xlsx":
+                    shutil.copy2(fp, output_path)
+                else:
+                    pd.read_csv(fp, low_memory=False).to_excel(output_path, index=False, engine="xlsxwriter")
+                log_message(f"    Placed (already formatted): {fp.name} -> {client_output_dir}", log_file)
+                success_count += 1
+                continue
+
+            # Raw file -- read with the same preamble skip the ZIP path uses.
+            if fp.suffix.lower() == ".xlsx":
+                df = pd.read_excel(fp)
+            else:
+                df = pd.read_csv(fp, skiprows=4, low_memory=False)
+
+            if df.empty:
+                log_message(f"    Skipping empty: {fp.name}", log_file)
+                continue
+
+            if not _looks_like_raw_odd(df):
+                log_message(
+                    f"    ERROR: {fp.name} does not look like a raw ODD after skipping header rows "
+                    f"(columns: {list(df.columns)[:6]}). Refusing to format.",
+                    log_file,
+                )
+                error_count += 1
+                continue
+
+            # Drop first column if it's an index column (same rule as the ZIP path).
+            if str(df.columns[0]).startswith("Unnamed") or df.iloc[:, 0].dtype == "int64":
+                df = df.drop(columns=[df.columns[0]])
+
+            log_message(f"    Formatting (from path): {fp.name} ({len(df):,} rows, {len(df.columns)} cols)", log_file)
+            df = format_odd(df)
+            df.to_excel(output_path, index=False, engine="xlsxwriter")
+            log_message(f"    Done: {fp.stem}.xlsx ({os.path.getsize(output_path) / 1024 / 1024:.1f} MB) -> {client_output_dir}", log_file)
+            success_count += 1
+
+        except Exception as e:
+            log_message(f"    ERROR formatting {fp.name}: {e}", log_file)
             error_count += 1
 
     return success_count, error_count
@@ -384,6 +501,9 @@ def main():
                         help="Process only this CSM (default: all)")
     parser.add_argument("--client", type=str, default=None,
                         help="Process only this client ID (default: all)")
+    parser.add_argument("--source-file", type=str, default=None,
+                        help="Format this exact ODD file/folder for --csm/--month/--client, "
+                             "bypassing the ZIP auto-scan (UI 'Generate from a path' flow)")
     parser.add_argument("--force", action="store_true",
                         help="Re-process even if output already exists")
     parser.add_argument("--config", type=str, default=None,
@@ -449,6 +569,30 @@ def main():
         log_dir = output_base / month
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = str(log_dir / "formatting_log.txt")
+
+    # Issue #229: explicit single file/folder -> format into the canonical
+    # output, bypassing the per-CSM ZIP auto-scan. Requires csm + client.
+    if args.source_file:
+        if not (args.csm and args.client):
+            print("ERROR: --source-file requires --csm and --client (and --month).")
+            sys.exit(2)
+        output = output_base / args.csm / month
+        log_message("", log_file)
+        log_message(f"  Source-file mode: {args.source_file}", log_file)
+        log_message(f"    CSM:    {args.csm}", log_file)
+        log_message(f"    Client: {args.client}", log_file)
+        log_message(f"    Output: {output}", log_file)
+        s, e = process_source_file(args.source_file, args.csm, month, args.client, str(output), log_file, force=True)
+        print()
+        print("=" * 70)
+        log_message("  STEP 1 COMPLETE (source-file)", log_file)
+        log_message(f"    Formatted: {s} file(s)", log_file)
+        if e:
+            log_message(f"    Errors:    {e}", log_file)
+        log_message(f"    Output:    {output}", log_file)
+        print("=" * 70)
+        print()
+        return
 
     log_message(f"  Config loaded:", log_file)
     log_message(f"    Staging:     {staging_base}", log_file)

--- a/01_Analysis/run.py
+++ b/01_Analysis/run.py
@@ -150,6 +150,21 @@ def _find_odd_file(csm, month, client_id):
             if matches:
                 return matches[0]
 
+    # Last resort: any .xlsx for this client anywhere under the CSM/month
+    # folder, however it's named or nested. Keeps this finder in step with the
+    # UI's (which had a leniency fix this one missed) so a real formatted file
+    # is never reported missing (#231).
+    for csm_dir in csm_dirs:
+        month_dir = csm_dir / month
+        if not month_dir.is_dir():
+            continue
+        cands = sorted(
+            f for f in month_dir.rglob("*.xlsx")
+            if f.is_file() and client_id in f.name and not f.name.startswith("~$")
+        )
+        if cands:
+            return cands[0]
+
     return None
 
 

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -65,6 +65,25 @@ COMPLETED_ANALYSIS = ANALYSIS_BASE / "01_Completed_Analysis"
 # In-memory run tracking
 runs = {}
 
+# Short-TTL cache for the dropdown directory scans (#229). Picking a CSM /
+# month / client re-walks the network share each time; over SMB that's slow.
+# Cache results for a minute so flipping around the dropdowns is instant.
+# Pass refresh=true (the UI's Refresh button) to force a fresh scan.
+_SCAN_CACHE: dict = {}
+_SCAN_TTL_SECONDS = 60.0
+
+
+def _scan_cached(key: str, producer, refresh: bool = False):
+    """Return a cached scan result, or run ``producer()`` and cache it."""
+    now = time.time()
+    if not refresh:
+        hit = _SCAN_CACHE.get(key)
+        if hit is not None and (now - hit[0]) < _SCAN_TTL_SECONDS:
+            return hit[1]
+    value = producer()
+    _SCAN_CACHE[key] = (now, value)
+    return value
+
 
 # ─── HELPERS ──────────────────────────────────────────────────────────
 
@@ -355,83 +374,8 @@ def _clients_from_folder(base: Path, csm: str, month: str) -> set[str]:
     return {d.name for d in csm_dir.iterdir() if d.is_dir()}
 
 
-@app.post("/api/stage")
-async def stage_formatted_odd(
-    src_path: str,
-    csm: str,
-    month: str,
-    client_id: str,
-):
-    """Manually stage pre-formatted ODD files (#124).
-
-    For CSMs whose raw dump folder isn't accessible (Dan, Aaron, etc.),
-    the operator can paste a path to already-extracted ODD .xlsx files
-    and copy them into the canonical READY_FOR_ANALYSIS layout in one
-    click. Skips the 7-step formatting pipeline.
-
-    src_path: file or folder containing one or more .xlsx ODD files.
-    Returns: {copied: [...], skipped: [...], dest: "<destination dir>"}.
-    """
-    src = Path(os.path.expandvars(os.path.expanduser(src_path.strip())))
-    if not src.exists():
-        raise HTTPException(status_code=400, detail=f"Source path does not exist: {src}")
-
-    if not csm or not month or not client_id:
-        raise HTTPException(status_code=400, detail="csm, month, and client_id are all required")
-
-    # Build the destination using the canonical layout. Reuse fuzzy CSM matching
-    # so 'James' picks up the 'JamesG' folder if it already exists.
-    csm_dir = READY_FOR_ANALYSIS / csm
-    if not csm_dir.exists() and READY_FOR_ANALYSIS.exists():
-        for d in READY_FOR_ANALYSIS.iterdir():
-            if d.is_dir() and d.name.lower().startswith(csm.lower()):
-                csm_dir = d
-                break
-    dest_dir = csm_dir / month / client_id
-
-    try:
-        dest_dir.mkdir(parents=True, exist_ok=True)
-    except (PermissionError, OSError) as exc:
-        raise HTTPException(status_code=400, detail=f"Could not create destination {dest_dir}: {exc}")
-
-    # Gather source files. A single .xlsx file or a folder containing them.
-    sources: list[Path] = []
-    if src.is_file():
-        if src.suffix.lower() == ".xlsx":
-            sources = [src]
-        else:
-            raise HTTPException(status_code=400, detail=f"Source file must be .xlsx, got {src.suffix}")
-    else:  # directory
-        sources = sorted(src.glob("*.xlsx"))
-        if not sources:
-            raise HTTPException(status_code=400, detail=f"No .xlsx files found in {src}")
-
-    import shutil
-    copied: list[str] = []
-    skipped: list[str] = []
-    for fp in sources:
-        target = dest_dir / fp.name
-        if target.exists():
-            skipped.append(fp.name)
-            continue
-        try:
-            shutil.copy2(fp, target)
-            copied.append(fp.name)
-        except (PermissionError, OSError) as exc:
-            raise HTTPException(
-                status_code=500,
-                detail=f"Failed to copy {fp.name} to {target}: {exc}",
-            )
-
-    return {
-        "copied": copied,
-        "skipped": skipped,
-        "dest": str(dest_dir),
-    }
-
-
 @app.get("/api/clients")
-async def get_clients(csm: str = "", month: str = ""):
+async def get_clients(csm: str = "", month: str = "", refresh: bool = False):
     """Return client list from config.
 
     When csm and month are both provided, filter to clients that show up
@@ -445,6 +389,12 @@ async def get_clients(csm: str = "", month: str = ""):
 
     With no csm/month, returns the full config (used by Results-tab dropdown).
     """
+    cache_key = f"clients|{csm}|{month}"
+    if not refresh:
+        _hit = _SCAN_CACHE.get(cache_key)
+        if _hit is not None and (time.time() - _hit[0]) < _SCAN_TTL_SECONDS:
+            return _hit[1]
+
     config = load_clients_config()
 
     allowed_ids = None
@@ -485,6 +435,7 @@ async def get_clients(csm: str = "", month: str = ""):
                 "config": {},
             })
 
+    _SCAN_CACHE[cache_key] = (time.time(), clients)
     return clients
 
 
@@ -529,13 +480,19 @@ async def module_counts():
 
 
 @app.get("/api/months")
-async def get_months(csm: str = "", source: str = "all"):
+async def get_months(csm: str = "", source: str = "all", refresh: bool = False):
     """Return available months by scanning actual directories.
 
     source=raw: scan CSM source folders (raw data dumps -- for formatting step)
     source=formatted: scan 02-Data-Ready for Analysis (already formatted -- for analysis step)
     source=all: combine both
     """
+    cache_key = f"months|{csm}|{source}"
+    if not refresh:
+        _hit = _SCAN_CACHE.get(cache_key)
+        if _hit is not None and (time.time() - _hit[0]) < _SCAN_TTL_SECONDS:
+            return _hit[1]
+
     months = set()
 
     # Scan formatted output directory
@@ -561,7 +518,9 @@ async def get_months(csm: str = "", source: str = "all"):
 
     # Cap to most recent 6 months
     sorted_months = sorted(months, reverse=True)
-    return sorted_months[:6] or [datetime.now().strftime("%Y.%m")]
+    result = sorted_months[:6] or [datetime.now().strftime("%Y.%m")]
+    _SCAN_CACHE[cache_key] = (time.time(), result)
+    return result
 
 
 @app.get("/api/files/{csm}/{month}/{client_id}")
@@ -736,6 +695,7 @@ async def start_run(
     client_id: str,
     product: str = "ars",
     local_copy_path: str = "",
+    source_path: str = "",
 ):
     """Start a full pipeline run: format (if needed) + analysis + PPTX.
 
@@ -767,6 +727,14 @@ async def start_run(
             raise HTTPException(status_code=400, detail=f"Local copy path is not a directory: {candidate}")
         local_copy_resolved = str(candidate)
 
+    # Validate an explicit source path up front so we fail fast, not 20 min in (#229).
+    source_resolved = ""
+    if source_path.strip():
+        sp = Path(os.path.expandvars(os.path.expanduser(source_path.strip())))
+        if not sp.exists():
+            raise HTTPException(status_code=400, detail=f"Source path does not exist: {sp}")
+        source_resolved = str(sp)
+
     runs[run_id] = {
         "status": "running",
         "client_id": client_id,
@@ -782,15 +750,24 @@ async def start_run(
     def _run():
         try:
             odd_file = find_formatted_odd(csm, month, client_id)
-            if not odd_file and formatting_run.exists():
+            # With an explicit source path (#229) we always (re)format from that
+            # file; otherwise we only format when no formatted ODD exists yet.
+            need_format = bool(source_resolved) or not odd_file
+            if need_format and formatting_run.exists():
                 runs[run_id]["current_step"] = "Step 1: Formatting ODD file..."
                 runs[run_id]["log"].append("=" * 60)
                 runs[run_id]["log"].append("  STEP 1: Formatting ODD file")
+                if source_resolved:
+                    runs[run_id]["log"].append(f"  Source: {source_resolved}")
                 runs[run_id]["log"].append("=" * 60)
 
+                fmt_cmd = [sys.executable, "-u", str(formatting_run),
+                           "--month", month, "--csm", csm, "--client", client_id]
+                if source_resolved:
+                    fmt_cmd += ["--source-file", source_resolved, "--force"]
+
                 fmt_proc = subprocess.Popen(
-                    [sys.executable, "-u", str(formatting_run),
-                     "--month", month, "--csm", csm, "--client", client_id],
+                    fmt_cmd,
                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                     text=True, encoding="utf-8", errors="replace",
                     bufsize=1,

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -629,13 +629,28 @@ async def start_format(
     month: str,
     client_id: str = "",
     force: bool = False,
+    source_path: str = "",
 ):
-    """Start a formatting run."""
+    """Start a formatting run.
+
+    With source_path (#229), format an explicit file/folder for a CSM whose raw
+    dump folder isn't reachable -- bypasses the ZIP auto-scan. Requires client_id.
+    """
     run_id = f"fmt_{client_id or 'all'}_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:4]}"
 
     formatting_run = ARS_BASE / "00_Formatting" / "run.py"
     if not formatting_run.exists():
         raise HTTPException(status_code=500, detail=f"Formatting run.py not found at {formatting_run}")
+
+    # Validate an explicit source path up front so we fail fast (#229).
+    source_resolved = ""
+    if source_path.strip():
+        sp = Path(os.path.expandvars(os.path.expanduser(source_path.strip())))
+        if not sp.exists():
+            raise HTTPException(status_code=400, detail=f"Source path does not exist: {sp}")
+        if not client_id:
+            raise HTTPException(status_code=400, detail="A client ID is required when formatting from a source path.")
+        source_resolved = str(sp)
 
     runs[run_id] = {
         "status": "running",
@@ -655,6 +670,9 @@ async def start_format(
                    "--month", month, "--csm", csm, "--with-trans"]
             if client_id:
                 cmd.extend(["--client", client_id])
+            if source_resolved:
+                # --source-file mode formats this exact file (forces internally).
+                cmd.extend(["--source-file", source_resolved])
             if force:
                 cmd.append("--force")
 

--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -823,6 +823,12 @@ async def start_run(
                    "--product", product]
             if local_copy_resolved:
                 cmd += ["--local-copy", local_copy_resolved]
+            # Hand the analysis step the exact ODD we already located, so it
+            # doesn't re-discover it with a separate finder that can drift out
+            # of sync (#231: app found it, analysis's stricter finder didn't).
+            # odd_file is guaranteed set here -- we returned above otherwise.
+            if odd_file:
+                cmd.append(str(odd_file))
 
             # Forward SLIDE_MODE and SLIDE_BUDGET so UI-set deck-size
             # controls reach the analysis subprocess. Without this, the

--- a/05_UI/index.html
+++ b/05_UI/index.html
@@ -517,41 +517,8 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
         <button class="btn btn-dark" onclick="runFormat(true)">Force Re-Format (overwrite existing)</button>
     </div>
 
-    <!-- Manual data-drop (#124): for CSMs without shared dump folder access -->
-    <details class="stage-card" style="margin-top:24px;">
-        <summary style="cursor:pointer;font-weight:700;font-size:15px;padding:14px 18px;background:var(--card);border:2px solid var(--border);border-radius:8px;list-style:none;">
-            Don't have access to a CSM's raw dump folder? <span style="color:var(--accent);">Drop pre-formatted ODD files here &rsaquo;</span>
-        </summary>
-        <div class="card" style="margin-top:8px;border-radius:8px;">
-            <div class="card-header">
-                <div>
-                    <div class="card-title">Stage pre-formatted ODD files</div>
-                    <div class="card-meta">Skips the 7-step formatter. Use when someone hands you an already-extracted ODD <code>.xlsx</code> for a CSM whose raw dump folder you can't see (Dan, Aaron, etc.).</div>
-                </div>
-            </div>
-            <div class="config-row" style="margin-bottom:16px;">
-                <div class="config-field"><div class="label">Source path</div>
-                    <input type="text" id="stageSrcPath" class="sel" placeholder="e.g. C:\Users\you\Downloads\1745_ODDD or a single .xlsx file" />
-                </div>
-            </div>
-            <div class="config-row" style="margin-bottom:16px;">
-                <div class="config-field"><div class="label">CSM</div>
-                    <select class="sel" id="stageCsmSel"><option value="">Loading...</option></select>
-                </div>
-                <div class="config-field"><div class="label">Period</div>
-                    <input type="text" id="stageMonth" class="sel" placeholder="2026.05" />
-                </div>
-                <div class="config-field"><div class="label">Client ID</div>
-                    <input type="text" id="stageClientId" class="sel" placeholder="1745" />
-                </div>
-            </div>
-            <div style="font-size:12px;color:var(--muted);margin-bottom:14px;">
-                Source path can be a folder (we copy every <code>.xlsx</code> matching ODD naming) or a single file. The destination is <code>02-Data-Ready for Analysis\&lt;CSM&gt;\&lt;period&gt;\&lt;client&gt;\</code> and is created automatically. Once staged, the file shows up in the Generate tab's client list.
-            </div>
-            <button class="btn" id="stageBtn" onclick="runStage()">Stage files</button>
-            <div id="stageResult" style="margin-top:14px;display:none;"></div>
-        </div>
-    </details>
+    <!-- Manual data-drop moved to the Generate tab (#229): paste a file/folder
+         path there and one click formats + analyzes + builds the deck. -->
 
     <div class="prog-section card" id="fProg" style="margin-top:24px;">
         <!-- Wave 4 follow-up: stage checklist + completion card parity
@@ -624,6 +591,19 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
                     <option value="">Loading...</option>
                 </select>
             </div>
+        </div>
+
+        <!-- Source-path override (#229): for CSMs whose dump folder isn't auto-detected.
+             Paste a file/folder path; client + period auto-fill from the filename, and
+             one Generate click formats + analyzes + builds the deck. -->
+        <div style="margin-top:18px;border-top:1px solid var(--border);padding-top:16px;">
+            <div class="label" style="display:flex;justify-content:space-between;align-items:center;">
+                <span>Source file / folder path <span style="font-weight:400;color:var(--muted);">— optional, only if this client isn't in the list above</span></span>
+                <button type="button" onclick="forceRefreshGen()" title="Re-scan the share for new clients/periods" style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:12px;">&#8635; Refresh lists</button>
+            </div>
+            <input type="text" id="gSourcePath" class="sel" oninput="parseSourcePath()"
+                   placeholder="e.g. \\padmis105\Velocity_Company\ARS\00_Formatting\Unprocessed ODDs\1815-2026-06-FedChoice FCU-ODD ...csv" />
+            <div id="gSourceParsed" style="font-size:12px;color:var(--muted);margin-top:6px;display:none;"></div>
         </div>
     </div>
 
@@ -1215,13 +1195,18 @@ async function refreshGenClients() {
                 sel.value = prev;
             }
         }
+        // #229: a re-scan wipes a from-file client option -- re-inject it.
+        if ((document.getElementById('gSourcePath')?.value || '').trim()) {
+            parseSourcePath();
+            return;
+        }
         updateGenClientFromAPI();
     } catch(e) {}
 }
 
 async function loadCSMs() {
     // Populate BOTH Format and Generate CSM dropdowns from API
-    const selectors = ['gCsmSel', 'fCsmSel', 'stageCsmSel'];
+    const selectors = ['gCsmSel', 'fCsmSel'];
     try {
         const resp = await fetch('/api/csms');
         if (!resp.ok) throw '';
@@ -1758,15 +1743,84 @@ async function _startCompanionRun(csm, month, clientId, prod) {
     }
 }
 
+// #229: ensure a value is selectable in a dropdown, injecting an option when
+// the client/period isn't discoverable on the share (the whole point of the
+// source-path flow).
+function _setOrInjectOption(selectId, value, label) {
+    const sel = document.getElementById(selectId);
+    if (!sel || !value) return;
+    let opt = [...sel.options].find(o => o.value === value);
+    if (!opt) {
+        opt = document.createElement('option');
+        opt.value = value;
+        opt.textContent = label || value;
+        opt.dataset.config = '{}';
+        opt.dataset.name = label || value;
+        opt.dataset.fromfile = '1';
+        sel.appendChild(opt);
+    }
+    sel.value = value;
+}
+
+// #229: parse client id + period out of a dropped ODD path and pre-fill the
+// dropdowns. CSM can't be parsed from the filename -- operator picks that.
+function parseSourcePath() {
+    const raw = (document.getElementById('gSourcePath').value || '').trim();
+    const info = document.getElementById('gSourceParsed');
+    if (!raw) { if (info) info.style.display = 'none'; return; }
+
+    const name = raw.split(/[\\/]/).pop() || raw;          // last path segment
+    const clientMatch = name.match(/^(\d{3,})/);            // leading digits
+    const monthMatch = name.match(/(20\d{2})[._-](0[1-9]|1[0-2])/);  // YYYY-MM
+
+    const clientId = clientMatch ? clientMatch[1] : '';
+    const month = monthMatch ? `${monthMatch[1]}.${monthMatch[2]}` : '';
+
+    if (month) _setOrInjectOption('gMonthSel', month, month);
+    if (clientId) _setOrInjectOption('gClientSel', clientId, `${clientId} — (from file)`);
+    if (clientId && typeof updateGenClientFromAPI === 'function') updateGenClientFromAPI();
+
+    if (info) {
+        const csm = document.getElementById('gCsmSel')?.value || '';
+        const parts = [
+            clientId ? `client <b>${clientId}</b>` : 'client <b>?</b> — type it above',
+            month ? `period <b>${month}</b>` : 'period <b>?</b> — pick it above',
+            csm ? `CSM <b>${csm}</b>` : 'CSM <b>?</b> — pick your name above',
+        ];
+        info.innerHTML = 'Parsed: ' + parts.join(' &middot; ')
+            + '. Click <b>Generate</b> to format + analyze + build the deck from this file.';
+        info.style.display = '';
+    }
+}
+
+// #229: bust the server-side scan cache and repopulate the dropdowns.
+function forceRefreshGen() {
+    const csm = document.getElementById('gCsmSel')?.value || '';
+    const month = document.getElementById('gMonthSel')?.value || '';
+    const clientsUrl = (csm && month)
+        ? `/api/clients?csm=${encodeURIComponent(csm)}&month=${encodeURIComponent(month)}&refresh=1`
+        : '/api/clients?refresh=1';
+    Promise.all([
+        fetch('/api/months?source=all&refresh=1').catch(() => {}),
+        fetch(clientsUrl).catch(() => {}),
+    ]).finally(() => {
+        if (typeof loadMonths === 'function') loadMonths();
+        refreshGenClients();
+    });
+}
+
 // Real pipeline run via API
 async function runGenReal() {
     const clientId = document.getElementById('gClientSel').value;
     const csm = document.getElementById('gCsmSel').value;
     const month = document.getElementById('gMonthSel').value;
+    const sourcePath = (document.getElementById('gSourcePath')?.value || '').trim();
     const clientLabel = document.querySelector('#gClientSel option:checked')?.textContent || `Client ${clientId}`;
 
     if (!csm || !month || !clientId) {
-        alert('Please select a CSM, period, and client first.');
+        alert(sourcePath
+            ? 'Pick your CSM name above. Client and period should auto-fill from the file path.'
+            : 'Please select a CSM, period, and client first.');
         return;
     }
 
@@ -1827,7 +1881,8 @@ async function runGenReal() {
 
     try {
         const runUrl = `/api/run?csm=${encodeURIComponent(csm)}&month=${encodeURIComponent(month)}&client_id=${encodeURIComponent(clientId)}&product=${encodeURIComponent(curProd)}`
-            + (localCopyPath ? `&local_copy_path=${encodeURIComponent(localCopyPath)}` : '');
+            + (localCopyPath ? `&local_copy_path=${encodeURIComponent(localCopyPath)}` : '')
+            + (sourcePath ? `&source_path=${encodeURIComponent(sourcePath)}` : '');
         const resp = await fetch(runUrl, {method: 'POST'});
         if (!resp.ok) {
             const errText = await resp.text();
@@ -2511,58 +2566,8 @@ loadDashboardData();
     } catch (e) {}
 })();
 
-// Manual data-drop (#124): stage pre-formatted ODD files for CSMs without
-// shared dump access. Calls POST /api/stage which copies the source
-// .xlsx(es) into the canonical READY_FOR_ANALYSIS folder.
-async function runStage() {
-    const srcPath = (document.getElementById('stageSrcPath').value || '').trim();
-    const csm = document.getElementById('stageCsmSel').value;
-    const month = (document.getElementById('stageMonth').value || '').trim();
-    const clientId = (document.getElementById('stageClientId').value || '').trim();
-
-    const result = document.getElementById('stageResult');
-    result.style.display = 'block';
-
-    if (!srcPath || !csm || !month || !clientId) {
-        result.innerHTML = `<div style="color:#EB2A2E;font-size:14px;">Need all four: source path, CSM, period, and client ID.</div>`;
-        return;
-    }
-
-    const btn = document.getElementById('stageBtn');
-    btn.disabled = true;
-    btn.textContent = 'Staging...';
-    btn.style.opacity = '0.6';
-    result.innerHTML = `<div style="color:var(--muted);font-size:13px;">Copying files…</div>`;
-
-    try {
-        const url = `/api/stage?src_path=${encodeURIComponent(srcPath)}&csm=${encodeURIComponent(csm)}&month=${encodeURIComponent(month)}&client_id=${encodeURIComponent(clientId)}`;
-        const resp = await fetch(url, {method: 'POST'});
-        const data = await resp.json().catch(() => ({}));
-        if (!resp.ok) {
-            const msg = data.detail || resp.statusText;
-            result.innerHTML = `<div style="color:#EB2A2E;font-size:14px;">Error: ${msg}</div>`;
-            return;
-        }
-        const copied = data.copied || [];
-        const skipped = data.skipped || [];
-        const dest = data.dest || '';
-        let html = `<div style="color:#2A8B3E;font-weight:700;font-size:14px;margin-bottom:8px;">✓ Staged ${copied.length} file(s) to ${dest}</div>`;
-        if (copied.length) {
-            html += `<div style="font-family:'Space Mono',monospace;font-size:12px;color:var(--muted);">${copied.map(f => '+ ' + f).join('<br>')}</div>`;
-        }
-        if (skipped.length) {
-            html += `<div style="margin-top:8px;color:#B5651D;font-size:12px;">Skipped (no overwrite): ${skipped.join(', ')}</div>`;
-        }
-        html += `<div style="margin-top:8px;color:var(--muted);font-size:11px;">Client ${clientId} should now appear in the Generate tab's client list for ${csm} / ${month}.</div>`;
-        result.innerHTML = html;
-    } catch(e) {
-        result.innerHTML = `<div style="color:#EB2A2E;font-size:14px;">Could not reach the API: ${e.message}</div>`;
-    } finally {
-        btn.disabled = false;
-        btn.textContent = 'Stage files';
-        btn.style.opacity = '';
-    }
-}
+// Manual data-drop replaced by the Generate tab's source-path field (#229):
+// paste a path there and one Generate click formats + analyzes + builds the deck.
 
 async function runFormat(force = false) {
     const csm = document.getElementById('fCsmSel').value;

--- a/05_UI/index.html
+++ b/05_UI/index.html
@@ -487,6 +487,15 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
                 <input class="sel" type="text" id="fClientId" placeholder="e.g. 1200 or leave blank for all">
             </div>
         </div>
+
+        <!-- Source-path override (#229): format a file directly for CSMs whose
+             dump folder isn't reachable (Dan, Aaron). Formats only -- no deck. -->
+        <div style="margin-top:18px;border-top:1px solid var(--border);padding-top:16px;">
+            <div class="label">Source file / folder path <span style="font-weight:400;color:var(--muted);">— optional, for CSMs whose dump folder isn't reachable</span></div>
+            <input type="text" id="fSourcePath" class="sel" oninput="parseFormatSourcePath()"
+                   placeholder="e.g. \\padmis105\Velocity_Company\ARS\00_Formatting\Unprocessed ODDs\1815-2026-06-FedChoice FCU-ODD ...csv" />
+            <div id="fSourceParsed" style="font-size:12px;color:var(--muted);margin-top:6px;display:none;"></div>
+        </div>
     </div>
 
     <div class="card" style="margin-bottom: 24px;">
@@ -1793,6 +1802,34 @@ function parseSourcePath() {
     }
 }
 
+// #229: same parse for the Format tab (client there is a text input, not a select).
+function parseFormatSourcePath() {
+    const raw = (document.getElementById('fSourcePath').value || '').trim();
+    const info = document.getElementById('fSourceParsed');
+    if (!raw) { if (info) info.style.display = 'none'; return; }
+
+    const name = raw.split(/[\\/]/).pop() || raw;
+    const clientMatch = name.match(/^(\d{3,})/);
+    const monthMatch = name.match(/(20\d{2})[._-](0[1-9]|1[0-2])/);
+    const clientId = clientMatch ? clientMatch[1] : '';
+    const month = monthMatch ? `${monthMatch[1]}.${monthMatch[2]}` : '';
+
+    if (month) _setOrInjectOption('fMonthSel', month, month);
+    if (clientId) document.getElementById('fClientId').value = clientId;
+
+    if (info) {
+        const csm = document.getElementById('fCsmSel')?.value || '';
+        const parts = [
+            clientId ? `client <b>${clientId}</b>` : 'client <b>?</b>',
+            month ? `period <b>${month}</b>` : 'period <b>?</b> — pick it above',
+            csm ? `CSM <b>${csm}</b>` : 'CSM <b>?</b> — pick your name above',
+        ];
+        info.innerHTML = 'Parsed: ' + parts.join(' &middot; ')
+            + '. Click <b>Format ODD Files</b> to format this file (no deck).';
+        info.style.display = '';
+    }
+}
+
 // #229: bust the server-side scan cache and repopulate the dropdowns.
 function forceRefreshGen() {
     const csm = document.getElementById('gCsmSel')?.value || '';
@@ -2573,9 +2610,14 @@ async function runFormat(force = false) {
     const csm = document.getElementById('fCsmSel').value;
     const month = document.getElementById('fMonthSel').value;
     const clientId = document.getElementById('fClientId').value.trim();
+    const sourcePath = (document.getElementById('fSourcePath')?.value || '').trim();
 
     if (!csm || !month) {
         alert('Please select a CSM and period first.');
+        return;
+    }
+    if (sourcePath && !clientId) {
+        alert('Enter the client ID (it should auto-fill from the file path).');
         return;
     }
 
@@ -2609,7 +2651,8 @@ async function runFormat(force = false) {
     _markFormatStage('locate', 'start');
 
     try {
-        const url = `/api/format?csm=${csm}&month=${month}&client_id=${clientId}&force=${force}`;
+        const url = `/api/format?csm=${encodeURIComponent(csm)}&month=${encodeURIComponent(month)}&client_id=${encodeURIComponent(clientId)}&force=${force}`
+            + (sourcePath ? `&source_path=${encodeURIComponent(sourcePath)}` : '');
         st.textContent = 'Connecting...';
         const resp = await fetch(url, {method: 'POST'});
         if (!resp.ok) {

--- a/Start Here.bat
+++ b/Start Here.bat
@@ -10,14 +10,23 @@ echo.
 echo   (Keep this window open while using the UI)
 echo.
 
-REM --- Find the Python bundle installed by "CSM Setup.bat" ---
+REM --- Choose a Python: prefer the bundle if it's installed, otherwise fall
+REM     back to a system Python already on this machine. Machines that have
+REM     run this for months have their own Python and no bundle -- that's fine. ---
+set "PYEXE="
 set "VELOCITY_PY=%LOCALAPPDATA%\Velocity\python\python.exe"
-if not exist "%VELOCITY_PY%" (
+if exist "%VELOCITY_PY%" (
+    set "PYEXE=%VELOCITY_PY%"
+) else (
+    where python >nul 2>nul && set "PYEXE=python"
+)
+
+if not defined PYEXE (
     color 0C
-    echo   This computer has not been set up yet.
+    echo   No Python found on this computer.
     echo.
-    echo   Please double-click "CSM Setup.bat" once and wait for "Done",
-    echo   then run "Start Here.bat" again.
+    echo   Either install Python, or double-click "CSM Setup.bat" once
+    echo   ^(wait for "Done"^), then run "Start Here.bat" again.
     echo.
     pause >nul
     exit /b 1
@@ -36,8 +45,8 @@ if errorlevel 1 (
     exit /b 1
 )
 
-REM --- Start the server in the background using the bundled Python ---
-start "" /b "%VELOCITY_PY%" app.py
+REM --- Start the server in the background using the chosen Python ---
+start "" /b "%PYEXE%" app.py
 
 echo   Waiting for server...
 :wait_loop


### PR DESCRIPTION
## What the operator sees

On the **Generate tab**, for a client whose dump folder isn't auto-detected (Dan, Aaron, ...): paste the file/folder path, your **CSM name**, and click **Generate**. Client + period auto-fill from the filename. One click formats → analyzes → builds the deck — same as any normal client.

The separate **"Stage pre-formatted ODD files"** panel is gone. That two-step "stage, then go generate" flow was the confusion in #229, and the old Stage step only *copied* files and rejected `.csv` (`Source file must be .xlsx, got .csv`).

## Why

#229: Dan's client 1815 is a `.csv` raw ODD. The old Stage panel rejected it and, even for `.xlsx`, only copied — it explicitly *"Skips the 7-step formatting pipeline."* So a dropped file never actually got formatted.

## Changes

- **`run.py`** — additive `--source-file` mode: formats an explicit ODD file/folder into the canonical `02-Data-Ready` location, reusing the exact ZIP-path logic (skip 4 preamble rows → drop index column → 7-step `format_odd` → `.xlsx`). Auto-detects already-formatted files (`check_odd_formatted`) so they're placed not double-formatted; a **header-sanity guard** refuses a file that doesn't look like a raw ODD instead of writing garbage. **Existing ZIP path untouched.**
- **`/api/run`** — optional `source_path` → passes `--source-file --force`; fails fast if the path is missing.
- **Dropdown speed** — short-TTL (60s) cache on `/api/months` and `/api/clients` (the slow per-flip network-share scans), plus a **Refresh lists** button (`refresh=1`) to force a re-scan.
- **UI** — Generate tab gains the optional source-path field + filename auto-parse. Removed the Stage panel, `/api/stage`, and `runStage()`.
- **Test** — `00_Formatting/00-Scripts/tests/test_source_file.py` (raw→formatted, sanity guard).

## Verified (on macOS dev)

- Backend boots; `/api/months`, `/api/clients`, caching + `refresh=1` work; bad `source_path` → 400.
- `run.py --source-file` formats a synthetic raw ODD end-to-end → all 5 signature columns, index column dropped, 4 preamble rows skipped.
- JS syntax valid; 2 unit tests pass.

## Not yet verified / prereqs

- **Not run on Windows/UNC** or against a real ODD file. The `skiprows=4` assumption is guarded by the sanity check, but the first real file is the true test.
- **Client must be in `clients_config.json`** for correct eligibility — **`1815` is currently missing**, so its deck would generate but with empty eligibility (the #29 class of bug). Adding 1815's stat/product codes is a separate step.

Branch off `main`, **not for merge yet** — pull onto a test machine, try it, and we'll bring it back to `main` once it's confirmed on real data.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)