### PR TITLE
fix(formatting): never crash the run when the log file is unwritable (#232)

### DIFF
--- a/00_Formatting/run.py
+++ b/00_Formatting/run.py
@@ -40,11 +40,24 @@ from settings import load_settings
 from shared.format_odd import format_odd
 
 
+# Log files we've already failed to write to. A locked or permission-denied
+# log must degrade to console-only with a single warning, never abort the
+# formatting run (issue #232).
+_disabled_log_files = set()
+
+
 def log_message(message, log_file=None):
     print(message)
-    if log_file:
+    if not log_file or log_file in _disabled_log_files:
+        return
+    try:
         with open(log_file, "a", encoding="utf-8") as f:
             f.write(message + "\n")
+    except OSError as exc:
+        _disabled_log_files.add(log_file)
+        reason = exc.strerror or exc
+        print(f"  WARNING: cannot write log file, continuing with console "
+              f"output only ({reason}): {log_file}")
 
 
 def load_ars_config():
@@ -442,13 +455,20 @@ def main():
     # Output: 02-Data-Ready for Analysis (formatted files go here)
     output_base = settings.paths.watch_root
 
-    # Log file -- saved per CSM if filtering, otherwise at month level
+    # Log file -- saved per CSM if filtering, otherwise at month level. An
+    # unwritable destination must not abort the run; fall back to console-only
+    # logging (issue #232).
     if args.csm:
         log_dir = output_base / args.csm / month
     else:
         log_dir = output_base / month
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = str(log_dir / "formatting_log.txt")
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = str(log_dir / "formatting_log.txt")
+    except OSError as exc:
+        log_file = None
+        print(f"  WARNING: cannot create log directory, continuing with "
+              f"console output only ({exc.strerror or exc}): {log_dir}")
 
     log_message(f"  Config loaded:", log_file)
     log_message(f"    Staging:     {staging_base}", log_file)

--- a/00_Formatting/tests/test_run_logging.py
+++ b/00_Formatting/tests/test_run_logging.py
@@ -1,0 +1,52 @@
+"""Regression tests for resilient logging in 00_Formatting/run.py.
+
+Issue #232: a locked or permission-denied formatting_log.txt raised
+PermissionError inside log_message and aborted the entire formatting run
+before a single file was processed. Logging must degrade to console-only
+instead of crashing.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import run  # noqa: E402
+
+
+def test_log_message_writes_to_file(tmp_path, capsys):
+    log_file = str(tmp_path / "formatting_log.txt")
+
+    run.log_message("hello", log_file)
+
+    assert "hello" in capsys.readouterr().out
+    assert Path(log_file).read_text(encoding="utf-8") == "hello\n"
+
+
+def test_log_message_survives_unwritable_log(tmp_path, capsys):
+    # A directory cannot be opened for append -- a portable stand-in for the
+    # locked / permission-denied file that crashed the run in issue #232.
+    unwritable = str(tmp_path)
+
+    # Must not raise.
+    run.log_message("first", unwritable)
+    run.log_message("second", unwritable)
+
+    out = capsys.readouterr().out
+    assert "first" in out
+    assert "second" in out
+    # The operator still sees the message and a warning, surfaced in the UI
+    # run log because run.py is launched with stdout piped to the UI.
+    assert "WARNING" in out
+
+
+def test_log_message_warns_only_once_per_log(tmp_path, capsys):
+    unwritable = str(tmp_path / "is_a_dir")
+    Path(unwritable).mkdir()
+
+    run.log_message("a", unwritable)
+    run.log_message("b", unwritable)
+    run.log_message("c", unwritable)
+
+    warnings = [ln for ln in capsys.readouterr().out.splitlines() if "WARNING" in ln]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Problem (issue #232)

A `python run.py` formatting run for **Dan / 1800 / 2026.06** crashed with:

```
PermissionError: [Errno 13] Permission denied:
'M:\ARS\00_Formatting\02-Data-Ready for Analysis\Dan\2026.06\formatting_log.txt'
```

The crash was **not** in the formatting logic — it died in `log_message`, before any ODD was processed. `log_message` opened `formatting_log.txt` for append on *every* call with no error handling (`00_Formatting/run.py:46`), so a locked or permission-denied log file took down the whole Step 1 run. With 50 log call sites, any one of them can abort the job.

## Fix

- `log_message` now wraps the file write in `try/except OSError`. On failure it prints a single `WARNING` and continues **console-only** for that log file (no per-call spam).
- The log-directory setup (`mkdir` + path) is guarded the same way, so an unwritable parent degrades to console-only instead of crashing.

Because `/api/format` launches `run.py` with `-u` and pipes **stdout** into the UI run log (`05_UI/app.py:702-713`) and `log_message` already `print()`s every message, **the operator now sees the warning in the UI run panel** instead of a hard crash. No UI changes were needed.

## Tests

Adds `00_Formatting/tests/test_run_logging.py` — a regression test that fails on the old code (`IsADirectoryError`/`OSError` out of `log_message`) and passes now, plus happy-path and warn-once coverage.

```
3 passed in 0.30s
```

## Deploying to the work machine

1. `git pull` on `M:\ARS\` (use `git stash && git pull` if the M: copy has local edits)
2. Close the **Velocity Pipeline** terminal window
3. Double-click `Start Here.bat`

> Note: the traceback in #232 came from a 729-line `run.py`; this repo's is 585 lines, so the M: drive copy has **diverged** (stale local edits or an old version). A plain `git pull` may report conflicts — stash first.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)