### PR TITLE
fix(formatting): resolve compact MMDDYY month-dump folders (#232)

### DIFF
--- a/00_Formatting/00-Scripts/month_resolver.py
+++ b/00_Formatting/00-Scripts/month_resolver.py
@@ -33,13 +33,60 @@ _NUM_YM_RE = re.compile(r"\b(20\d{2})[._\-/ ](\d{1,2})\b")
 _NUM_MY_RE = re.compile(r"\b(\d{1,2})[._\-/ ](20\d{2})\b")
 
 
+def _parse_compact_digits(s: str):
+    """Parse a separator-less numeric folder name into ``(year, month)``.
+
+    Handles the date-style dumps some CSMs use, e.g. Dan's ``060126``
+    (MMDDYY -> June 2026), as well as ``202606`` (YYYYMM), ``20260601``
+    (YYYYMMDD) and ``06012026`` (MMDDYYYY). Returns ``None`` when the digits
+    don't encode a valid month. A bare 4-digit year is intentionally not a
+    month and yields ``None``.
+    """
+    def valid_month(m):
+        return 1 <= m <= 12
+
+    def valid_day(d):
+        return 1 <= d <= 31
+
+    def valid_year(y):
+        return 2000 <= y <= 2099
+
+    if len(s) == 6:
+        # YYYYMM (e.g. 202606); years start with "20" so MM can't be 20+.
+        year, month = int(s[:4]), int(s[4:6])
+        if valid_year(year) and valid_month(month):
+            return (year, month)
+        # MMDDYY (e.g. 060126 -> June 2026).
+        month, day, yy = int(s[:2]), int(s[2:4]), int(s[4:6])
+        if valid_month(month) and valid_day(day):
+            return (2000 + yy, month)
+    elif len(s) == 8:
+        # YYYYMMDD (e.g. 20260601).
+        year, month, day = int(s[:4]), int(s[4:6]), int(s[6:8])
+        if valid_year(year) and valid_month(month) and valid_day(day):
+            return (year, month)
+        # MMDDYYYY (e.g. 06012026).
+        month, day, year = int(s[:2]), int(s[2:4]), int(s[4:8])
+        if valid_month(month) and valid_day(day) and valid_year(year):
+            return (year, month)
+    return None
+
+
 def parse_year_month(name: str):
     """Parse a folder name into ``(year, month)``, or ``None`` if it encodes no
-    month. Handles numeric (``2026.06``, ``2026-06``, ``06.2026``) and
-    month-name (``June, 2026``, ``Jun 2026``) forms."""
+    month. Handles numeric (``2026.06``, ``2026-06``, ``06.2026``), compact
+    date (``060126``, ``202606``) and month-name (``June, 2026``, ``Jun
+    2026``) forms."""
     if not name:
         return None
     s = name.strip().lower()
+
+    # Separator-less numeric dumps (e.g. Dan's MMDDYY folders); the regexes
+    # below all require a separator, so handle these first.
+    if s.isdigit():
+        compact = _parse_compact_digits(s)
+        if compact:
+            return compact
 
     m = _NUM_YM_RE.search(s)
     if m:

--- a/00_Formatting/tests/test_month_resolver.py
+++ b/00_Formatting/tests/test_month_resolver.py
@@ -1,0 +1,65 @@
+"""Tests for tolerant month-folder resolution.
+
+Issue #232 follow-up: Dan's monthly data-dump folders are named in a
+compact, separator-less ``MMDDYY`` form (``060126`` = June 1, 2026) rather
+than the ``2026.06`` / ``June 2026`` forms James and Jordan use. The
+resolver must recognise that format so the normal formatting flow can find
+the source folder.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "00-Scripts"))
+
+from month_resolver import parse_year_month, resolve_source_month_dir  # noqa: E402
+
+
+# --- Dan's compact MMDDYY folders ---------------------------------------
+
+def test_parses_mmddyy():
+    assert parse_year_month("010126") == (2026, 1)
+    assert parse_year_month("060126") == (2026, 6)
+    assert parse_year_month("120126") == (2026, 12)
+
+
+def test_parses_yyyymm_compact():
+    assert parse_year_month("202606") == (2026, 6)
+
+
+def test_parses_eight_digit_dates():
+    assert parse_year_month("20260601") == (2026, 6)  # YYYYMMDD
+    assert parse_year_month("06012026") == (2026, 6)  # MMDDYYYY
+
+
+# --- must not over-match -------------------------------------------------
+
+def test_year_only_folders_return_none():
+    assert parse_year_month("2024") is None
+    assert parse_year_month("2025") is None
+
+
+def test_invalid_compact_digits_return_none():
+    assert parse_year_month("130126") is None  # month 13
+    assert parse_year_month("999999") is None
+
+
+# --- existing James/Jordan formats still work ----------------------------
+
+def test_existing_formats_unaffected():
+    assert parse_year_month("2026.06") == (2026, 6)
+    assert parse_year_month("2026-06") == (2026, 6)
+    assert parse_year_month("06.2026") == (2026, 6)
+    assert parse_year_month("June 2026") == (2026, 6)
+    assert parse_year_month("Jun 2026") == (2026, 6)
+
+
+# --- end-to-end folder resolution ----------------------------------------
+
+def test_resolve_picks_mmddyy_folder(tmp_path):
+    for name in ("2024", "2025", "010126", "050126", "060126"):
+        (tmp_path / name).mkdir()
+
+    resolved = resolve_source_month_dir(tmp_path, "2026.06")
+
+    assert resolved == tmp_path / "060126"


### PR DESCRIPTION
## Problem (follow-up on #232)

Dan's monthly data-dump folders are named in a compact, **separator-less `MMDDYY`** form, not the `2026.06` / `June 2026` forms James and Jordan use:

```
2024   2025
010126  020126  030126  040126  050126  060126
```

`060126` = month 06 / day 01 / year 26 → **June 2026**.

`month_resolver.parse_year_month` only matched separated numeric (`2026.06`, `06.2026`) and month-name (`June 2026`) forms — all of which require a separator. Every one of Dan's folders parsed to `None`, so the normal formatting flow could not locate his source month. (The run in #232 only worked because it used the paste-a-path "source-file mode", which bypasses folder resolution.)

## Fix

Add `_parse_compact_digits` to handle separator-less numeric folders:

| Folder | Interpreted as | Result |
|--------|----------------|--------|
| `060126` | MMDDYY | (2026, 6) |
| `202606` | YYYYMM | (2026, 6) |
| `20260601` | YYYYMMDD | (2026, 6) |
| `06012026` | MMDDYYYY | (2026, 6) |
| `2024` | bare year | `None` (no month — correct) |
| `130126` | invalid month 13 | `None` |

Purely **additive** — existing James/Jordan formats are unaffected. Since years start with `20`, `YYYYMM` and `MMDDYY` are unambiguous (a leading `20` can't be a month).

## Tests

New `00_Formatting/tests/test_month_resolver.py` — covers each compact form, the no-over-match guards, the existing formats, and end-to-end `resolve_source_month_dir` picking the `060126` folder for month `2026.06`.

```
10 passed
```

Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)