### PR TITLE
fix(#232): coerce ODD column headers to str so analytics modules survive numeric headers

### DIFF
--- a/01_Analysis/00-Scripts/pipeline/steps/load.py
+++ b/01_Analysis/00-Scripts/pipeline/steps/load.py
@@ -199,7 +199,17 @@ def _detect_header_row(probe: pd.DataFrame, max_scan: int = 15) -> int:
 
 
 def _read_tabular(path: Path, reader) -> pd.DataFrame:
-    """Read excel/csv, auto-skipping a title/preamble row above the header."""
+    """Read excel/csv, auto-skipping a title/preamble row above the header.
+
+    Column labels are coerced to str: an ODD can carry numeric header cells
+    (e.g. a month labeled 202406, or a stray number in 1800's banner rows), and
+    analytics modules iterate df.columns with string ops -- `c.endswith(...)`,
+    `"Reg E" in c`, regex -- which raise on an int label and kill the whole
+    module (#232: mailer.*, insights.branch_scorecard/dormant/effectiveness).
+    A non-string header is never a real ODD field, so stringifying is safe and
+    lets those modules simply skip it. Existing string labels are unchanged --
+    we deliberately do NOT strip, so exact names like ' Acct Number' survive.
+    """
     probe = reader(path, header=None, nrows=15)
     hdr = _detect_header_row(probe)
     if hdr > 0:
@@ -207,7 +217,9 @@ def _read_tabular(path: Path, reader) -> pd.DataFrame:
             "Header row detected on row {n} -- skipping {n} title/preamble row(s) above it",
             n=hdr,
         )
-    return reader(path, header=hdr)
+    df = reader(path, header=hdr)
+    df.columns = [str(c) for c in df.columns]
+    return df
 
 
 def _read_file(path: Path) -> pd.DataFrame:

--- a/01_Analysis/00-Scripts/tests/test_load_normalize_columns.py
+++ b/01_Analysis/00-Scripts/tests/test_load_normalize_columns.py
@@ -98,6 +98,23 @@ def test_header_row_zero_is_not_second_guessed(tmp_path):
     assert len(ctx.data) == 1
 
 
+def test_numeric_headers_coerced_to_str(tmp_path):
+    """Numeric column headers must load as str so module column-name string ops
+    (c.endswith(...), 'Reg E' in c, regex) don't crash (#232: mailer.*, insights.*)."""
+    L.odd_cache_clear()
+    path = _write_xlsx(
+        tmp_path / "numhdr.xlsx",
+        REQUIRED + [202406, "Jan26 Reg E Code", "Jan26 Spend"],
+        [["100", "DDA", "2022-01-01", "50.0", 7, "Y", 12.5]],
+    )
+    ctx = _ctx()
+    L.step_load_file(ctx, path)
+    assert all(isinstance(c, str) for c in ctx.data.columns)
+    # The exact ops that killed insights.dormant / branch_scorecard must not raise.
+    assert [c for c in ctx.data.columns if c.endswith(" Spend")] == ["Jan26 Spend"]
+    assert [c for c in ctx.data.columns if "Reg E" in c and "Code" in c] == ["Jan26 Reg E Code"]
+
+
 def test_required_columns_match_whitespace_and_case(tmp_path):
     """Headers drift: ' Stat Code', 'prod code', 'AVG BAL' must still match."""
     L.odd_cache_clear()


### PR DESCRIPTION
Follow-up to the title-row fix. 1800 now loads (86,396 rows × 205 cols) and builds a deck, but 6 analytics modules crashed because some of those 205 headers are numeric and the modules iterate `df.columns` with string ops:

- `insights.dormant` → `'int' object has no attribute 'endswith'` (`c.endswith(" Spend")`)
- `insights.branch_scorecard` → `argument of type 'int' is not iterable` (`"Reg E" in c`)
- `mailer.insights` / `mailer.cohort` / `mailer.reach` / `insights.effectiveness` → regex on an int header

Fix: stringify every column label in the loader after read. A non-string header is never a real ODD field, so modules skip it instead of dying. Existing string labels unchanged (no strip → ' Acct Number' survives). New test + 40 in the load/pipeline/runner set pass.

refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)