### PR TITLE
Extract transaction files bundled inside ODD zips during formatting

### DIFF
--- a/00_Formatting/run.py
+++ b/00_Formatting/run.py
@@ -439,6 +439,102 @@ def gather_trans_files(src_directory, txn_output_base, csm_name, client_filter=N
     return success, errors
 
 
+def gather_trans_from_zips(src_directory, txn_output_base, csm_name, client_filter=None, log_file=None, clients_config=None):
+    """Extract transaction files bundled INSIDE the ODD zips into TXN Files.
+
+    CSM data-dump zips (e.g. 1200_ODDD.zip) now carry both the ODD entry and a
+    transaction entry. process_csm() extracts only ODD entries, so this pulls
+    the transaction entry out and routes it to TXN Files/{CSM}/{client_id}/ --
+    the same destination and detection/dedup contract as gather_trans_files().
+    The large ODD member is never decompressed here (only its metadata is read).
+    """
+    if not os.path.exists(src_directory):
+        return 0, 0
+
+    # Same ODD-zip discovery as process_csm (never modifies the CSM source)
+    zip_files = [f for f in os.listdir(src_directory) if f.endswith('.zip')
+                 and 'odd' in f.lower()
+                 and (client_filter is None or f.startswith(client_filter))]
+
+    success = 0
+    skipped = 0
+    errors = 0
+    for item in zip_files:
+        item_path = os.path.join(src_directory, item)
+        if not zipfile.is_zipfile(item_path):
+            continue
+
+        # Fallback client ID from the zip name (e.g. 1200 from 1200_ODDD.zip)
+        zip_client = re.match(r'^(\d+)', item)
+        zip_cid = zip_client.group(1) if zip_client else None
+
+        try:
+            with zipfile.ZipFile(item_path, 'r') as zip_ref:
+                for entry in zip_ref.namelist():
+                    if entry.startswith('__MACOSX') or entry.endswith('/'):
+                        continue
+                    base = os.path.basename(entry)
+                    f_lower = base.lower()
+
+                    # ODD wins -- already extracted/formatted by process_csm.
+                    # Also resolves an entry matching both 'odd' and 'tran'.
+                    if 'odd' in f_lower:
+                        continue
+
+                    # Same detection as gather_trans_files
+                    is_txn = (
+                        ('tran' in f_lower and f_lower.endswith(('.txt', '.csv')))
+                        or f_lower.endswith('_transaction')
+                    )
+                    if not is_txn:
+                        continue
+
+                    # Client ID: entry's leading digits, else the zip's client ID
+                    entry_match = re.match(r'^(\d+)', base)
+                    cid = entry_match.group(1) if entry_match else zip_cid
+                    if not cid:
+                        log_message(f"    Trans SKIPPED (no client ID in entry or zip name): {item}!{base}", log_file)
+                        continue
+
+                    # Skip excluded clients
+                    if clients_config and clients_config.get(cid, {}).get("exclude", False):
+                        continue
+                    if client_filter is not None and cid != client_filter:
+                        continue
+
+                    try:
+                        src_size = zip_ref.getinfo(entry).file_size
+
+                        # Destination: TXN Files/{CSM}/{client_id}/
+                        dest_dir = os.path.join(txn_output_base, csm_name, cid)
+                        os.makedirs(dest_dir, exist_ok=True)
+                        dest_path = os.path.join(dest_dir, base)
+
+                        # Skip if same file already exists (same name + same size)
+                        if os.path.exists(dest_path):
+                            if os.path.getsize(dest_path) == src_size:
+                                skipped += 1
+                                continue
+                            # Different size = updated file, overwrite
+                            log_message(f"    Trans (zip): {base} -- size changed, re-copying", log_file)
+
+                        with open(dest_path, 'wb') as out_f:
+                            out_f.write(zip_ref.read(entry))
+                        log_message(f"    Trans (zip): {item}!{base} -> {dest_dir}", log_file)
+                        success += 1
+                    except Exception as e:
+                        log_message(f"    Trans (zip) ERROR: {item}!{base}: {e}", log_file)
+                        errors += 1
+        except Exception as e:
+            log_message(f"    Trans (zip) ERROR opening {item}: {e}", log_file)
+            errors += 1
+
+    if skipped:
+        log_message(f"    Trans (zip): {skipped} file(s) already up to date", log_file)
+
+    return success, errors
+
+
 def gather_deferred_files(client_ids, deferred_base, output_directory, log_file=None):
     """Copy deferred revenue files for each client.
 
@@ -701,6 +797,11 @@ def main():
             csm_root = Path(csm_source)
             if csm_root.exists() and csm_root != src:
                 t_ok, t_err = gather_trans_files(str(csm_root), txn_base, csm_name, args.client, log_file, clients_config)
+                t_ok_total += t_ok
+                t_err_total += t_err
+            # Also pull TXN entries bundled inside the ODD zips (zips now carry both)
+            if src.exists():
+                t_ok, t_err = gather_trans_from_zips(str(src), txn_base, csm_name, args.client, log_file, clients_config)
                 t_ok_total += t_ok
                 t_err_total += t_err
             log_message(f"    Trans: {t_ok_total} copied, {t_err_total} errors", log_file)

--- a/00_Formatting/tests/test_trans_from_zip.py
+++ b/00_Formatting/tests/test_trans_from_zip.py
@@ -1,0 +1,97 @@
+"""Transaction files now ship INSIDE the ODD zips (e.g. 1200_ODDD.zip carries
+both the unformatted ODD and the transaction file). process_csm() extracts only
+ODD entries, so gather_trans_from_zips() pulls the transaction entry out and
+routes it to TXN Files/{CSM}/{client_id}/ where the analysis 'data dump' step
+reads it.
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import run  # noqa: E402
+
+
+def _make_zip(path, entries):
+    """entries: {arcname: bytes} -> writes a zip and returns its path."""
+    with zipfile.ZipFile(path, "w") as z:
+        for name, data in entries.items():
+            z.writestr(name, data)
+    return path
+
+
+def test_txn_entry_extracted_from_odd_zip(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _make_zip(src / "1200_ODDD.zip", {
+        "1200-2026-06-Guardians-ODD.csv": b"banner\nbanner\nbanner\nbanner\nAccount\n1\n",
+        "1200_transactions_2026.06.30.txt": b"date,amount\n2026-06-30,10\n",
+    })
+    txn_base = tmp_path / "TXN Files"
+
+    ok, err = run.gather_trans_from_zips(str(src), str(txn_base), "JamesG")
+
+    assert (ok, err) == (1, 0)
+    dest = txn_base / "JamesG" / "1200" / "1200_transactions_2026.06.30.txt"
+    assert dest.exists()
+    assert dest.read_bytes() == b"date,amount\n2026-06-30,10\n"
+    # The ODD entry must NOT be routed into TXN Files
+    assert list((txn_base / "JamesG" / "1200").iterdir()) == [dest]
+
+
+def test_client_id_falls_back_to_zip_name(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _make_zip(src / "1441_ODDD.zip", {
+        "somebank-ODD.csv": b"x",
+        "transactions.txt": b"a,b\n1,2\n",  # inner entry has no leading digits
+    })
+    txn_base = tmp_path / "TXN Files"
+
+    ok, err = run.gather_trans_from_zips(str(src), str(txn_base), "Dan")
+
+    assert (ok, err) == (1, 0)
+    assert (txn_base / "Dan" / "1441" / "transactions.txt").exists()
+
+
+def test_second_run_dedups_by_size(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _make_zip(src / "1200_ODDD.zip", {"1200_trans.csv": b"a,b\n1,2\n"})
+    txn_base = tmp_path / "TXN Files"
+
+    first_ok, _ = run.gather_trans_from_zips(str(src), str(txn_base), "JamesG")
+    second = run.gather_trans_from_zips(str(src), str(txn_base), "JamesG")
+
+    assert first_ok == 1
+    assert second == (0, 0)  # already present, same size -> skipped
+
+
+def test_entry_with_odd_and_tran_is_not_routed_to_txn(tmp_path):
+    # 'odd' wins: process_csm already handles it, so it must not land in TXN.
+    src = tmp_path / "src"
+    src.mkdir()
+    _make_zip(src / "1200_ODDD.zip", {"1200_odd_transactions.csv": b"a,b\n1,2\n"})
+    txn_base = tmp_path / "TXN Files"
+
+    ok, err = run.gather_trans_from_zips(str(src), str(txn_base), "JamesG")
+
+    assert (ok, err) == (0, 0)
+    assert not (txn_base / "JamesG" / "1200").exists()
+
+
+def test_excluded_client_is_skipped(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _make_zip(src / "1200_ODDD.zip", {"1200_trans.csv": b"a,b\n1,2\n"})
+    txn_base = tmp_path / "TXN Files"
+
+    ok, err = run.gather_trans_from_zips(
+        str(src), str(txn_base), "JamesG",
+        clients_config={"1200": {"exclude": True, "exclude_reason": "test"}},
+    )
+
+    assert (ok, err) == (0, 0)
+    assert not (txn_base / "JamesG" / "1200").exists()


### PR DESCRIPTION
## Summary

CSM data-dump zips (e.g. `1200_ODDD.zip`) now carry **both** the unformatted ODD file and the transaction file. The formatter's `process_csm()` extracts only `odd`-named entries, so the bundled transaction file was silently dropped and never reached the analysis "data dump" step.

This adds `gather_trans_from_zips()` in `00_Formatting/run.py`, which mirrors the existing `gather_trans_files()` but reads transaction entries from **inside** the ODD zips and routes them to `TXN Files/{CSM}/{client_id}/` — the folder the Analysis step (`01_Analysis/00-Scripts/analytics/txn_setup/02-file-config.py` → `pipeline/steps/txn_load.py`) already consumes.

## Details

- Wired into the existing `--with-trans` block in `_process_one_csm`, so the UI and scheduled runs pick it up automatically — **no CLI, UI, or config change**.
- Reuses the same contract as the loose-file gatherer: transaction detection (`'tran'` + `.txt`/`.csv`, or `_transaction`), client-id extraction, exclude checks, and dedup-by-size.
- ODD entries are skipped so they're never duplicated into TXN (also resolves an entry matching both `odd` and `tran`).
- Client id falls back to the zip name when the inner entry has no leading digits (e.g. `transactions.txt`).
- The large ODD member is never decompressed in this pass — only the small transaction entry is read.

## Testing

- New `00_Formatting/tests/test_trans_from_zip.py` — 5 cases: extraction, zip-name id fallback, size-based dedup, odd-wins, client exclusion.
- Full formatting suite: **20 passed, no regressions.**
- End-to-end on a scratch zip containing both files: ODD still formats to `.xlsx` **and** the transaction lands in `TXN Files/{CSM}/{client_id}/`, with no cross-contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYVdWQbArbNCZ8YWnn7jFa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYVdWQbArbNCZ8YWnn7jFa)_