### PR TITLE
Add emergency STOP ALL button to the formatting and generate UI

### DIFF
--- a/05_UI/app.py
+++ b/05_UI/app.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import threading
@@ -64,6 +65,90 @@ COMPLETED_ANALYSIS = ANALYSIS_BASE / "01_Completed_Analysis"
 
 # In-memory run tracking
 runs = {}
+
+# Live subprocess handle for each run, so the emergency STOP ALL can kill it.
+# Kept OUT of `runs` because that dict is JSON-serialized back to the UI and a
+# Popen object isn't serializable. Keyed by run_id; holds the currently-active
+# child (a run formats then analyses, so the handle is overwritten as it moves
+# from step to step).
+run_procs: dict = {}
+
+
+def _register_proc(run_id: str, proc) -> None:
+    """Track the currently-active child process for a run (for STOP ALL)."""
+    run_procs[run_id] = proc
+
+
+def _popen_tree_kwargs() -> dict:
+    """Popen kwargs that isolate the child so its whole tree can be killed.
+
+    The analysis step can fan out ProcessPoolExecutor worker processes; killing
+    only the top ``run.py`` would orphan them. On POSIX we give the child its own
+    session so ``os.killpg`` targets that group (and never the server's). On
+    Windows the tree is reaped by ``taskkill /T`` (no special flag needed).
+    """
+    if os.name == "posix":
+        return {"start_new_session": True}
+    return {}
+
+
+def _terminate_proc(proc) -> bool:
+    """Kill a child process AND its descendants. Returns True if a live process
+    was signalled; a no-op if ``proc`` is None or already exited."""
+    if proc is None or proc.poll() is not None:
+        return False
+    pid = proc.pid
+    try:
+        if os.name == "nt":
+            # /T kills the whole tree (analysis pool workers included), /F forces.
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                capture_output=True,
+            )
+        else:
+            # Capture the group up front -- once the leader dies os.getpgid raises.
+            pgid = os.getpgid(pid)
+            os.killpg(pgid, signal.SIGTERM)
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                pass
+            # Sweep the whole group: pool workers can outlive the parent, and a
+            # child that ignored SIGTERM still dies here.
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    except (ProcessLookupError, PermissionError, OSError):
+        # Fall back to terminating just the top process.
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    try:
+        proc.wait(timeout=5)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return True
+
+
+def _mark_terminal(run_id: str, status: str, progress: int | None = None) -> None:
+    """Set a run's final status -- but only if it's still ``running``.
+
+    A STOP ALL flips the status to ``stopped`` and kills the subprocess; the
+    worker thread then unblocks from its now-dead ``proc.wait()`` and would
+    otherwise overwrite that with ``error``. Guarding on the current status
+    keeps the operator's ``stopped`` verdict from being clobbered.
+    """
+    run = runs.get(run_id)
+    run_procs.pop(run_id, None)
+    if not run or run.get("status") != "running":
+        return
+    run["status"] = status
+    if progress is not None:
+        run["progress"] = progress
+    run["finished"] = datetime.now().isoformat()
+
 
 # A run still marked "running" after this many seconds is treated as dead (the
 # server never saw its subprocess finish -- a hard crash or hang) so a stuck
@@ -742,7 +827,9 @@ async def start_format(
                 text=True, encoding="utf-8", errors="replace",
                 bufsize=1,
                 cwd=str(formatting_run.parent),
+                **_popen_tree_kwargs(),
             )
+            _register_proc(run_id, proc)
             for line in proc.stdout:
                 line = line.rstrip()
                 if run_id in runs:
@@ -752,14 +839,12 @@ async def start_format(
                     runs[run_id]["progress"] = min(95, log_len * 3)
 
             proc.wait()
-            if run_id in runs:
-                runs[run_id]["status"] = "complete" if proc.returncode == 0 else "error"
-                runs[run_id]["progress"] = 100 if proc.returncode == 0 else runs[run_id]["progress"]
-                runs[run_id]["finished"] = datetime.now().isoformat()
+            _mark_terminal(run_id, "complete" if proc.returncode == 0 else "error",
+                           progress=100 if proc.returncode == 0 else None)
         except Exception as e:
             if run_id in runs:
-                runs[run_id]["status"] = "error"
                 runs[run_id]["log"].append(f"ERROR: {e}")
+            _mark_terminal(run_id, "error")
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
@@ -853,7 +938,9 @@ async def start_run(
                     text=True, encoding="utf-8", errors="replace",
                     bufsize=1,
                     cwd=str(formatting_run.parent),
+                    **_popen_tree_kwargs(),
                 )
+                _register_proc(run_id, fmt_proc)
                 for line in fmt_proc.stdout:
                     line = line.rstrip()
                     if run_id in runs:
@@ -870,9 +957,11 @@ async def start_run(
                 runs[run_id]["log"].append("")
 
             if not odd_file:
-                runs[run_id]["status"] = "error"
-                runs[run_id]["log"].append("ERROR: No formatted ODD file found after formatting.")
-                runs[run_id]["log"].append(f"Check: {READY_FOR_ANALYSIS / csm / month / client_id}")
+                # Suppress the error verdict/log if the operator already stopped it.
+                if runs.get(run_id, {}).get("status") == "running":
+                    runs[run_id]["log"].append("ERROR: No formatted ODD file found after formatting.")
+                    runs[run_id]["log"].append(f"Check: {READY_FOR_ANALYSIS / csm / month / client_id}")
+                    _mark_terminal(run_id, "error")
                 return
 
             product_label = {"ars": "ARS", "txn": "TXN", "combined": "ARS + TXN"}.get(product, "ARS")
@@ -906,7 +995,9 @@ async def start_run(
                 bufsize=1,
                 cwd=str(analysis_run.parent),
                 env=_run_env,
+                **_popen_tree_kwargs(),
             )
+            _register_proc(run_id, proc)
             runs[run_id]["last_output_at"] = datetime.now().isoformat()
             for line in proc.stdout:
                 line = line.rstrip()
@@ -918,14 +1009,12 @@ async def start_run(
                     runs[run_id]["progress"] = min(95, log_len * 2)
 
             proc.wait()
-            if run_id in runs:
-                runs[run_id]["status"] = "complete" if proc.returncode == 0 else "error"
-                runs[run_id]["progress"] = 100 if proc.returncode == 0 else runs[run_id]["progress"]
-                runs[run_id]["finished"] = datetime.now().isoformat()
+            _mark_terminal(run_id, "complete" if proc.returncode == 0 else "error",
+                           progress=100 if proc.returncode == 0 else None)
         except Exception as e:
             if run_id in runs:
-                runs[run_id]["status"] = "error"
                 runs[run_id]["log"].append(f"ERROR: {e}")
+            _mark_terminal(run_id, "error")
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
@@ -961,13 +1050,40 @@ async def stream_run(run_id: str):
 
             yield f"data: {json.dumps({'type': 'progress', 'value': run['progress'], 'step': run['current_step']})}\n\n"
 
-            if run["status"] in ("complete", "error"):
+            if run["status"] in ("complete", "error", "stopped"):
                 yield f"data: {json.dumps({'type': 'done', 'status': run['status']})}\n\n"
                 break
 
             await asyncio.sleep(0.5)
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+@app.post("/api/stop_all")
+async def stop_all():
+    """Emergency stop: kill every in-progress formatting/analysis run and its
+    whole child-process tree, right now.
+
+    Safe to hit at any time -- a no-op if nothing is running. Files already
+    written to disk are kept; only the in-flight work is aborted. Each stopped
+    run is flipped to the terminal ``stopped`` status so the UI's poll loop
+    ends and the buttons re-enable.
+    """
+    stopped = []
+    for run_id, run in list(runs.items()):
+        if run.get("status") != "running":
+            continue
+        _terminate_proc(run_procs.get(run_id))
+        run_procs.pop(run_id, None)
+        run["status"] = "stopped"
+        run["current_step"] = "Stopped by operator"
+        run["finished"] = datetime.now().isoformat()
+        run["log"].append("")
+        run["log"].append("=" * 60)
+        run["log"].append("  STOPPED BY OPERATOR (emergency STOP ALL)")
+        run["log"].append("=" * 60)
+        stopped.append(run_id)
+    return {"stopped": len(stopped), "run_ids": stopped}
 
 
 def _resolve_csm_dir(base_path: Path, csm: str) -> Path:
@@ -1553,7 +1669,9 @@ async def run_schedule_now(schedule_id: str):
                     fmt_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                     text=True, encoding="utf-8", errors="replace", bufsize=1,
                     cwd=str(formatting_run.parent),
+                    **_popen_tree_kwargs(),
                 )
+                _register_proc(run_id, proc)
                 for line in proc.stdout:
                     if run_id in runs:
                         runs[run_id]["log"].append(line.rstrip())
@@ -1567,7 +1685,9 @@ async def run_schedule_now(schedule_id: str):
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 text=True, encoding="utf-8", errors="replace", bufsize=1,
                 cwd=str(analysis_run.parent),
+                **_popen_tree_kwargs(),
             )
+            _register_proc(run_id, proc)
             for line in proc.stdout:
                 if run_id in runs:
                     runs[run_id]["log"].append(line.rstrip())
@@ -1575,10 +1695,8 @@ async def run_schedule_now(schedule_id: str):
                     runs[run_id]["progress"] = min(95, len(runs[run_id]["log"]) * 2)
             proc.wait()
 
-            if run_id in runs:
-                runs[run_id]["status"] = "complete" if proc.returncode == 0 else "error"
-                runs[run_id]["progress"] = 100 if proc.returncode == 0 else runs[run_id]["progress"]
-                runs[run_id]["finished"] = datetime.now().isoformat()
+            _mark_terminal(run_id, "complete" if proc.returncode == 0 else "error",
+                           progress=100 if proc.returncode == 0 else None)
 
             # Update schedule last_run
             schedules = _load_schedules()
@@ -1590,8 +1708,8 @@ async def run_schedule_now(schedule_id: str):
 
         except Exception as e:
             if run_id in runs:
-                runs[run_id]["status"] = "error"
                 runs[run_id]["log"].append(f"ERROR: {e}")
+            _mark_terminal(run_id, "error")
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()

--- a/05_UI/index.html
+++ b/05_UI/index.html
@@ -89,6 +89,8 @@ header {
 .btn:hover { background: var(--accent-dark); }
 .btn-dark { background: var(--dark); }
 .btn-dark:hover { background: #444; }
+.btn-danger { background: var(--red); }
+.btn-danger:hover { background: #c81f22; }
 .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
 .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
 .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
@@ -524,6 +526,7 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
     <div style="display:flex;gap:12px;">
         <button class="btn" onclick="runFormat()">Format ODD Files</button>
         <button class="btn btn-dark" onclick="runFormat(true)">Force Re-Format (overwrite existing)</button>
+        <button class="btn btn-danger" onclick="stopAll()" title="Emergency: immediately kill every running formatting and generate job" style="margin-left:auto;">&#9632; STOP ALL</button>
     </div>
 
     <!-- Manual data-drop moved to the Generate tab (#229): paste a file/folder
@@ -652,7 +655,10 @@ footer { text-align: center; padding: 28px; font-size: 11px; color: var(--faint)
                 <div class="run-what" id="gRunWhat">Select a client and product</div>
                 <div class="run-meta" id="gRunMeta">--</div>
             </div>
-            <button class="btn" id="genRunBtn" onclick="smartRunGen()">Format + Analyze + Build PPTX</button>
+            <div style="display:flex;gap:10px;align-items:center;">
+                <button class="btn" id="genRunBtn" onclick="smartRunGen()">Format + Analyze + Build PPTX</button>
+                <button class="btn btn-danger" onclick="stopAll()" title="Emergency: immediately kill every running formatting and generate job">&#9632; STOP ALL</button>
+            </div>
         </div>
 
         <!-- Local copy option -->
@@ -1739,6 +1745,9 @@ async function _startCompanionRun(csm, month, clientId, prod) {
                     clearInterval(timer);
                     state.innerHTML = '<span style="color:var(--green);font-weight:700;">complete</span> — deck + outputs in Downloads below';
                     loadDownloads(csm, month, clientId);
+                } else if (run.status === 'stopped') {
+                    clearInterval(timer);
+                    state.innerHTML = '<span style="color:var(--dark);font-weight:700;">stopped</span> — emergency stop';
                 } else if (run.status === 'error' || run.status === 'failed') {
                     clearInterval(timer);
                     state.innerHTML = '<span style="color:var(--red);font-weight:700;">FAILED</span> — see History tab / logs';
@@ -2036,7 +2045,7 @@ async function runGenReal() {
                     log.scrollTop = log.scrollHeight;
                 }
 
-                if (run.status === 'complete' || run.status === 'error') {
+                if (run.status === 'complete' || run.status === 'error' || run.status === 'stopped') {
                     clearInterval(pollInterval);
                     clearInterval(clockTimer);
                     // Mark any still-pending stages done if complete
@@ -2614,6 +2623,31 @@ loadDashboardData();
 // Manual data-drop replaced by the Generate tab's source-path field (#229):
 // paste a path there and one Generate click formats + analyzes + builds the deck.
 
+// Emergency stop: kill every in-progress formatting/generate job right now.
+// The per-run poll loops (which watch for a terminal status) then wind the UI
+// down on their own -- clearing timers, re-enabling buttons -- when they see
+// the run flip to "stopped".
+async function stopAll() {
+    if (!confirm('EMERGENCY STOP\n\nThis immediately kills every running formatting and generate job. Files already written are kept, but the current run will be left incomplete.\n\nStop everything now?')) {
+        return;
+    }
+    try {
+        const resp = await fetch('/api/stop_all', {method: 'POST'});
+        if (!resp.ok) {
+            alert('Stop request failed: ' + (resp.statusText || resp.status));
+            return;
+        }
+        const data = await resp.json();
+        if (data.stopped > 0) {
+            alert(`Stopped ${data.stopped} running job${data.stopped === 1 ? '' : 's'}.`);
+        } else {
+            alert('Nothing was running.');
+        }
+    } catch (e) {
+        alert('Could not reach the server to stop jobs: ' + e.message);
+    }
+}
+
 async function runFormat(force = false) {
     const csm = document.getElementById('fCsmSel').value;
     const month = document.getElementById('fMonthSel').value;
@@ -2716,8 +2750,8 @@ async function runFormat(force = false) {
                 bar.style.width = run.progress + '%';
                 st.textContent = run.current_step || 'Running...';
 
-                // Done?
-                if (run.status === 'complete' || run.status === 'error') {
+                // Done? ("stopped" = operator hit the emergency STOP ALL)
+                if (run.status === 'complete' || run.status === 'error' || run.status === 'stopped') {
                     clearInterval(pollInterval);
                     clearInterval(fmtTick);
                     window._formatInFlight = false;
@@ -2763,6 +2797,9 @@ async function runFormat(force = false) {
                             window.scrollTo({top: 0, behavior: 'smooth'});
                         };
                         actions.appendChild(again);
+                    } else if (run.status === 'stopped') {
+                        st.textContent = 'Stopped by operator';
+                        bar.style.background = 'var(--dark)';
                     } else {
                         st.textContent = 'Error -- check log below';
                         bar.style.background = '#EB2A2E';

--- a/05_UI/tests/test_stop_all.py
+++ b/05_UI/tests/test_stop_all.py
@@ -1,0 +1,98 @@
+"""Emergency STOP ALL: kill every in-progress run and its child-process tree.
+
+The launch sites store each live subprocess in ``run_procs`` so ``/api/stop_all``
+can terminate it; ``_mark_terminal`` guards the operator's ``stopped`` verdict
+against the worker thread that finishes its (now-killed) subprocess and would
+otherwise overwrite it with ``error``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+
+def _running(**extra):
+    base = {
+        "status": "running", "csm": "TestCSM", "month": "2026.04",
+        "client_id": "9999", "product": "ars",
+        "started": datetime.now().isoformat(), "progress": 10,
+        "current_step": "working", "log": [],
+    }
+    base.update(extra)
+    return base
+
+
+def test_stop_all_noop_when_idle(app_module):
+    app_module.runs.clear()
+    app_module.run_procs.clear()
+    client = TestClient(app_module.app)
+    resp = client.post("/api/stop_all")
+    assert resp.status_code == 200
+    assert resp.json() == {"stopped": 0, "run_ids": []}
+
+
+def test_stop_all_kills_running_job(app_module):
+    app_module.runs.clear()
+    app_module.run_procs.clear()
+
+    # A real, long-lived child we expect STOP ALL to kill.
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(120)"],
+        **app_module._popen_tree_kwargs(),
+    )
+    rid = "run_under_test"
+    app_module.runs[rid] = _running()
+    app_module._register_proc(rid, proc)
+
+    client = TestClient(app_module.app)
+    resp = client.post("/api/stop_all")
+
+    assert resp.json() == {"stopped": 1, "run_ids": [rid]}
+    assert app_module.runs[rid]["status"] == "stopped"
+    assert rid not in app_module.run_procs  # handle cleaned up
+    # Child is actually dead (give the OS a beat to reap it).
+    for _ in range(50):
+        if proc.poll() is not None:
+            break
+        time.sleep(0.1)
+    assert proc.poll() is not None, "child process survived STOP ALL"
+
+
+def test_mark_terminal_does_not_clobber_stopped(app_module):
+    """After STOP ALL flips a run to 'stopped', the worker thread's terminal
+    write (which runs when its killed subprocess unblocks) must be ignored."""
+    app_module.runs.clear()
+    app_module.run_procs.clear()
+    rid = "r1"
+    app_module.runs[rid] = _running(status="stopped")
+
+    app_module._mark_terminal(rid, "error", progress=100)
+
+    assert app_module.runs[rid]["status"] == "stopped"
+
+
+def test_mark_terminal_sets_status_when_running(app_module):
+    app_module.runs.clear()
+    app_module.run_procs.clear()
+    rid = "r1"
+    app_module.runs[rid] = _running()
+    app_module.run_procs[rid] = object()  # sentinel handle to prove cleanup
+
+    app_module._mark_terminal(rid, "complete", progress=100)
+
+    assert app_module.runs[rid]["status"] == "complete"
+    assert app_module.runs[rid]["progress"] == 100
+    assert "finished" in app_module.runs[rid]
+    assert rid not in app_module.run_procs
+
+
+def test_terminate_proc_noop_on_none_and_dead(app_module):
+    assert app_module._terminate_proc(None) is False
+    done = subprocess.Popen([sys.executable, "-c", "pass"])
+    done.wait()
+    assert app_module._terminate_proc(done) is False


### PR DESCRIPTION
## Summary

Adds a red **STOP ALL** button to both the **Format** and **Generate** pages that immediately kills every in-progress formatting/analysis job **and its whole child-process tree**. Previously the UI launched each job as a subprocess inside a daemon thread but never kept the `Popen` handle, so there was no way to abort a run once it started.

## Backend (`05_UI/app.py`)

- **`run_procs` registry** tracks each run's live subprocess (kept out of `runs`, which is JSON-serialized to the UI). The handle is registered at all five launch sites: `/api/format`, `/api/run`'s format + analysis steps, and the scheduled-run path's format + analysis steps.
- **`POST /api/stop_all`** terminates every running job's process tree and flips it to a terminal `stopped` status. No-op when nothing is running.
- **`_terminate_proc`** kills the whole tree so the analysis `ProcessPoolExecutor` workers can't orphan: `taskkill /PID /T /F` on Windows; on POSIX the child is launched in its own session (`start_new_session`) and the process group gets `SIGTERM` followed by a `SIGKILL` sweep.
- **`_mark_terminal`** sets a run's final status only if it's still `running`, so the worker thread finishing its killed subprocess can't overwrite the operator's `stopped` verdict with `error`. All completion/except paths route through it, and the SSE stream treats `stopped` as terminal.

## Frontend (`05_UI/index.html`)

- Red **STOP ALL** button on the Format and Generate pages, wired to a `stopAll()` confirm-then-POST helper; new `.btn-danger` style.
- The format, generate, and companion-run poll loops treat `stopped` as a terminal state, so their timers stop and buttons re-enable, showing "Stopped by operator."

## Testing

- New `05_UI/tests/test_stop_all.py`: idle no-op, a real subprocess killed via the endpoint, the anti-clobber guard, and terminate no-ops.
- Verified end-to-end that a process-with-grandchild is fully reaped (no orphaned pool workers), and that the running server serves both buttons and the route.
- **Full UI suite green: 24 passed** (19 existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYVdWQbArbNCZ8YWnn7jFa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYVdWQbArbNCZ8YWnn7jFa)_